### PR TITLE
fix to handle class

### DIFF
--- a/src/com/koxudaxi/pydantic/PydanticInspection.kt
+++ b/src/com/koxudaxi/pydantic/PydanticInspection.kt
@@ -8,8 +8,10 @@ import com.jetbrains.python.inspections.PyInspectionVisitor
 import com.jetbrains.python.psi.PyCallExpression
 import com.jetbrains.python.psi.PyClass
 import com.jetbrains.python.psi.PyKeywordArgument
+import com.jetbrains.python.psi.impl.PyClassImpl
 import com.jetbrains.python.psi.impl.PyReferenceExpressionImpl
 import com.jetbrains.python.psi.impl.PyStarArgumentImpl
+import com.jetbrains.python.psi.impl.references.PyReferenceImpl
 import com.jetbrains.python.psi.resolve.PyResolveContext
 import com.jetbrains.python.psi.types.PyClassTypeImpl
 
@@ -26,14 +28,7 @@ class PydanticInspection : PyInspection() {
             super.visitPyCallExpression(node)
 
             if (node != null) {
-                val resolveContext = PyResolveContext.noImplicits().withTypeEvalContext(myTypeEvalContext)
-                val markedCallee = node.multiResolveCallee(resolveContext).singleOrNull()
-                val callee = markedCallee?.element
-
-                if (markedCallee != null && callee != null) {
-                    return
-                }
-                val pyClass: PyClass = (myTypeEvalContext.getType(node) as? PyClassTypeImpl)?.pyClass ?: return
+                val pyClass: PyClass = (node.callee?.reference as PyReferenceImpl).resolve() as? PyClass ?: return
                 if (!pyClass.isSubclass("pydantic.main.BaseModel", myTypeEvalContext)) return
                 if ((node.callee as PyReferenceExpressionImpl).isQualified) return
                 for (argument in node.arguments) {


### PR DESCRIPTION
## Detail
When Calling object, The plugin may detect an object as other class.
Also, if the class is multiple inheritances, then the plugin doesn't show a warning message.
The PR fixes it.


## Related issues
https://github.com/koxudaxi/pydantic-pycharm-plugin/issues/17