### PR TITLE
Support BaseSettings

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,9 +1,14 @@
 <idea-plugin url="https://github.com/koxudaxi/pydantic-pycharm-plugin">
     <id>com.koxudaxi.pydantic</id>
     <name>Pydantic</name>
-    <version>0.0.12</version>
+    <version>0.0.13</version>
     <vendor email="koaxudai@gmail.com">Koudai Aono @koxudaxi</vendor>
     <change-notes><![CDATA[
+    <h2>version 0.0.13</h2>
+    <p>Features</p>
+    <ul>
+        <li>No arguments required for BaseSettings [#] </li>
+    </ul>
     <h2>version 0.0.12</h2>
     <p>Features</p>
     <ul>


### PR DESCRIPTION
## Detail 
The PR removes  warning of arguments is requierd because `BaseSettings` can parse environment variables in `__init__`

## Related Issues
https://github.com/koxudaxi/pydantic-pycharm-plugin/issues/32