### PR TITLE
Support to search related fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@
 * Model-specific `__init__`-arguments type-checking for subclasses of `pydantic.BaseModel` 
 * Refactor support for renaming fields for subclasses of `BaseModel`
   * (If the field name is refactored from the model definition or `__init__` call keyword arguments, PyCharm will present a dialog offering the choice to automatically rename the keyword where it occurs in a model initialization call.
-* Search related-fields by class attributes and keyword arguments of __init__. with Ctrl+B and Cmd+B
+* Search related-fields by class attributes and keyword arguments of `__init__` with `Ctrl+B` and `Cmd+B`
+
 
 ## How to install:
 ### MarketPlace 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 * Model-specific `__init__`-arguments type-checking for subclasses of `pydantic.BaseModel` 
 * Refactor support for renaming fields for subclasses of `BaseModel`
   * (If the field name is refactored from the model definition or `__init__` call keyword arguments, PyCharm will present a dialog offering the choice to automatically rename the keyword where it occurs in a model initialization call.
-
+* Search related-fields by class attributes and keyword arguments of __init__. with Ctrl+B and Cmd+B
 
 ## How to install:
 ### MarketPlace 

--- a/build.gradle
+++ b/build.gradle
@@ -36,16 +36,16 @@ allprojects {
     compileKotlin {
         kotlinOptions {
             jvmTarget = "1.8"
-            languageVersion = "1.2"
-            apiVersion = "1.2"
+            languageVersion = "1.3"
+            apiVersion = "1.3"
         }
     }
 
     compileTestKotlin {
         kotlinOptions {
             jvmTarget = "1.8"
-            languageVersion = "1.2"
-            apiVersion = "1.2"
+            languageVersion = "1.3"
+            apiVersion = "1.23"
         }
     }
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -50,6 +50,7 @@
                          enabledByDefault="true" level="WARNING"
                          implementationClass="com.koxudaxi.pydantic.PydanticInspection"/>
         <automaticRenamerFactory implementation="com.koxudaxi.pydantic.PydanticFieldRenameFactory"/>
+        <referencesSearch implementation="com.koxudaxi.pydantic.PydanticFieldSearchExecutor"/>
     </extensions>
     <extensions defaultExtensionNs="Pythonid">
         <typeProvider implementation="com.koxudaxi.pydantic.PydanticTypeProvider"/>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,9 +1,14 @@
 <idea-plugin url="https://github.com/koxudaxi/pydantic-pycharm-plugin">
     <id>com.koxudaxi.pydantic</id>
     <name>Pydantic</name>
-    <version>0.0.13</version>
+    <version>0.0.14</version>
     <vendor email="koaxudai@gmail.com">Koudai Aono @koxudaxi</vendor>
     <change-notes><![CDATA[
+    <h2>version 0.0.14</h2>
+    <p>Features</p>
+    <ul>
+        <li>Search related-fields by class attributes and keyword arguments of __init__. with Ctrl+B and Cmd+B [#42] </li>
+    </ul>
     <h2>version 0.0.13</h2>
     <p>Features, BugFixes</p>
     <ul>
@@ -29,6 +34,7 @@
                <li>Model-specific __init__-arguments type-checking for subclasses of pydantic.BaseModel</li>
                <li>Refactor support for renaming fields for subclasses of BaseModel</li>
                 <li>(If the field name is refactored from the model definition or __init__ call keyword arguments, PyCharm will present a dialog offering the choice to automatically rename the keyword where it occurs in a model initialization call.</li>
+               <li>Search related-fields by class attributes and keyword arguments of __init__. with Ctrl+B and Cmd+B</li>
             </ul>
          </li>
         <li>pydantic.dataclasses.dataclass

--- a/src/com/koxudaxi/pydantic/PydanticBaseModel.kt
+++ b/src/com/koxudaxi/pydantic/PydanticBaseModel.kt
@@ -1,0 +1,11 @@
+package com.koxudaxi.pydantic
+
+import com.jetbrains.python.psi.PyCallExpression
+import com.jetbrains.python.psi.PyClass
+import com.jetbrains.python.psi.PyKeywordArgument
+
+
+fun getPyClassByPyKeywordArgument(pyKeywordArgument: PyKeywordArgument) : PyClass? {
+    val pyCallExpression = pyKeywordArgument.parent?.parent as? PyCallExpression ?: return null
+    return pyCallExpression.callee?.reference?.resolve() as? PyClass ?: return null
+}

--- a/src/com/koxudaxi/pydantic/PydanticFieldRenameFactory.kt
+++ b/src/com/koxudaxi/pydantic/PydanticFieldRenameFactory.kt
@@ -121,8 +121,3 @@ class PydanticFieldRenameFactory : AutomaticRenamerFactory {
     }
 
 }
-
-private fun getPyClassByPyKeywordArgument(pyKeywordArgument: PyKeywordArgument) : PyClass? {
-    val pyCallExpression = pyKeywordArgument.parent?.parent as? PyCallExpression ?: return null
-    return pyCallExpression.callee?.reference?.resolve() as? PyClass ?: return null
-}

--- a/src/com/koxudaxi/pydantic/PydanticFieldSearchExecutor.kt
+++ b/src/com/koxudaxi/pydantic/PydanticFieldSearchExecutor.kt
@@ -1,0 +1,94 @@
+package com.koxudaxi.pydantic
+
+import com.intellij.openapi.application.QueryExecutorBase
+import com.intellij.openapi.application.ReadAction.run
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiReference
+import com.intellij.psi.search.searches.ReferencesSearch
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.util.Processor
+import com.jetbrains.python.psi.PyCallExpression
+import com.jetbrains.python.psi.PyClass
+import com.jetbrains.python.psi.PyKeywordArgument
+import com.jetbrains.python.psi.PyTargetExpression
+import com.jetbrains.python.psi.search.PyClassInheritorsSearch
+
+private fun searchField(pyClass: PyClass, elementName: String, consumer: Processor<in PsiReference>, single: Boolean = false): Boolean {
+    if (!pyClass.isSubclass("pydantic.main.BaseModel", null)) return false
+    pyClass.classAttributes.forEach { pyTargetExpression ->
+        if (pyTargetExpression.name == elementName) {
+            consumer.process(pyTargetExpression.reference)
+            if (single) return true
+        }
+    }
+    return false
+}
+
+private fun searchKeywordArgument(pyClass: PyClass, elementName: String, consumer: Processor<in PsiReference>) {
+    if (!pyClass.isSubclass("pydantic.main.BaseModel", null)) return
+    ReferencesSearch.search(pyClass as PsiElement).forEach { psiReference ->
+        val callee = PsiTreeUtil.getParentOfType(psiReference.element, PyCallExpression::class.java)
+        callee?.arguments?.forEach { argument ->
+            if (argument is PyKeywordArgument && argument.name == elementName) {
+                consumer.process(argument.reference)
+
+            }
+        }
+    }
+}
+
+private fun searchDirectReferenceField(pyClass: PyClass, elementName: String, consumer: Processor<in PsiReference>): Boolean {
+    if (searchField(pyClass, elementName, consumer, true)) {
+        return true
+    }
+    pyClass.getAncestorClasses(null).forEach {  ancestorClass ->
+        if (ancestorClass.qualifiedName != "pydantic.main.BaseModel") {
+            if (ancestorClass.isSubclass("pydantic.main.BaseModel", null)) {
+                if (searchDirectReferenceField(ancestorClass, elementName, consumer)) {
+                    return true
+                }
+            }
+            }
+        }
+    return false
+    }
+
+private fun searchAllElementReference(pyClass: PyClass?, elementName: String, added: MutableSet<PyClass>, consumer: Processor<in PsiReference>) {
+    if (pyClass == null) return
+    added.add(pyClass)
+    searchField(pyClass, elementName, consumer)
+    searchKeywordArgument(pyClass, elementName, consumer)
+    pyClass.getAncestorClasses(null).forEach {  ancestorClass ->
+        if (ancestorClass.qualifiedName != "pydantic.main.BaseModel") {
+            if (ancestorClass.isSubclass("pydantic.main.BaseModel", null) &&
+                    !added.contains(ancestorClass)) {
+                searchAllElementReference(ancestorClass, elementName, added, consumer)
+            }
+        }
+    }
+    PyClassInheritorsSearch.search(pyClass, true).forEach { inheritorsPyClass ->
+        if (inheritorsPyClass.qualifiedName != "pydantic.main.BaseModel" && ! added.contains(inheritorsPyClass)) {
+            searchAllElementReference(inheritorsPyClass, elementName, added, consumer)
+        }
+    }
+}
+class PydanticFieldSearchExecutor : QueryExecutorBase<PsiReference, ReferencesSearch.SearchParameters>() {
+    override fun processQuery(queryParameters: ReferencesSearch.SearchParameters, consumer: Processor<in PsiReference>) {
+        val element = queryParameters.elementToSearch
+
+        when (element) {
+            is PyKeywordArgument -> run<RuntimeException> {
+                val elementName = element.name ?: return@run
+                val pyClass = getPyClassByPyKeywordArgument(element) ?: return@run
+                if (!pyClass.isSubclass("pydantic.main.BaseModel", null)) return@run
+                searchDirectReferenceField(pyClass, elementName, consumer)
+            }
+            is PyTargetExpression -> run<RuntimeException> {
+                val elementName = element.name ?: return@run
+                val pyClass = element.containingClass ?: return@run
+                if (!pyClass.isSubclass("pydantic.main.BaseModel", null)) return@run
+                searchAllElementReference(pyClass, elementName, mutableSetOf(), consumer)
+            }
+        }
+        }
+    }

--- a/src/com/koxudaxi/pydantic/PydanticFieldSearchExecutor.kt
+++ b/src/com/koxudaxi/pydantic/PydanticFieldSearchExecutor.kt
@@ -58,20 +58,13 @@ private fun searchAllElementReference(pyClass: PyClass?, elementName: String, ad
     added.add(pyClass)
     searchField(pyClass, elementName, consumer)
     searchKeywordArgument(pyClass, elementName, consumer)
-    pyClass.getAncestorClasses(null).forEach {  ancestorClass ->
-        if (ancestorClass.qualifiedName != "pydantic.main.BaseModel") {
-            if (ancestorClass.isSubclass("pydantic.main.BaseModel", null) &&
-                    !added.contains(ancestorClass)) {
-                searchAllElementReference(ancestorClass, elementName, added, consumer)
-            }
-        }
-    }
     PyClassInheritorsSearch.search(pyClass, true).forEach { inheritorsPyClass ->
         if (inheritorsPyClass.qualifiedName != "pydantic.main.BaseModel" && ! added.contains(inheritorsPyClass)) {
             searchAllElementReference(inheritorsPyClass, elementName, added, consumer)
         }
     }
 }
+
 class PydanticFieldSearchExecutor : QueryExecutorBase<PsiReference, ReferencesSearch.SearchParameters>() {
     override fun processQuery(queryParameters: ReferencesSearch.SearchParameters, consumer: Processor<in PsiReference>) {
         val element = queryParameters.elementToSearch

--- a/src/com/koxudaxi/pydantic/PydanticFieldSearchExecutor.kt
+++ b/src/com/koxudaxi/pydantic/PydanticFieldSearchExecutor.kt
@@ -53,6 +53,11 @@ private fun searchAllElementReference(pyClass: PyClass?, elementName: String, ad
     added.add(pyClass)
     searchField(pyClass, elementName, consumer)
     searchKeywordArgument(pyClass, elementName, consumer)
+    pyClass.getAncestorClasses(null).forEach {  ancestorClass ->
+        if (ancestorClass.qualifiedName != "pydantic.main.BaseModel" &&  !added.contains(ancestorClass)){
+            searchField(pyClass, elementName, consumer)
+        }
+    }
     PyClassInheritorsSearch.search(pyClass, true).forEach { inheritorsPyClass ->
         if (inheritorsPyClass.qualifiedName != "pydantic.main.BaseModel" && !added.contains(inheritorsPyClass)) {
             searchAllElementReference(inheritorsPyClass, elementName, added, consumer)


### PR DESCRIPTION
## Detail
The PR supports to search related fields from class attributes and keywords arguments of `__init__`.

It means The plugin can jump between fields and keyword arguments of `__init__` with `ctrl+b`
I feel very very useful feature.

btw,  PyCharm does not support the futures for dataclass of python

## Related Issues
https://github.com/koxudaxi/pydantic-pycharm-plugin/issues/40

## ScreenShots
<img width="436" alt="ss2019-08-17 18 35 31" src="https://user-images.githubusercontent.com/630670/63209594-d697dd80-c11d-11e9-927d-f194a7ab4c96.png">
<img width="435" alt="ss2019-08-17 18 34 47" src="https://user-images.githubusercontent.com/630670/63209593-d697dd80-c11d-11e9-97a1-33c9d65f5f2f.png">

