### PR TITLE
Improve autocompletion for signature

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -7,6 +7,7 @@
     <h2>version 0.0.15</h2>
     <p>Features</p>
     <ul>
+        <li>Improve autocompletion for signature subclasses of pydantic.BaseModel and pydantic.dataclasses.dataclass [#] </li>
         <li>Update kotlin version to 1.3.50  [#50] </li>
         <li>Support to detect types by default value on Schema [#49] </li>
         <li>Improve inner logic [#47] </li>
@@ -67,6 +68,9 @@
                          implementationClass="com.koxudaxi.pydantic.PydanticInspection"/>
         <automaticRenamerFactory implementation="com.koxudaxi.pydantic.PydanticFieldRenameFactory"/>
         <referencesSearch implementation="com.koxudaxi.pydantic.PydanticFieldSearchExecutor"/>
+        <completion.contributor language="Python"
+                                implementationClass="com.koxudaxi.pydantic.PydanticCompletionContributor"/>
+
     </extensions>
     <extensions defaultExtensionNs="Pythonid">
         <typeProvider implementation="com.koxudaxi.pydantic.PydanticTypeProvider"/>

--- a/src/com/koxudaxi/pydantic/Pydantic.kt
+++ b/src/com/koxudaxi/pydantic/Pydantic.kt
@@ -1,5 +1,6 @@
 package com.koxudaxi.pydantic
 
+import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.QualifiedName
 import com.jetbrains.python.psi.*
 import com.jetbrains.python.psi.resolve.PyResolveUtil
@@ -17,7 +18,7 @@ fun getPyClassByPyCallExpression(pyCallExpression: PyCallExpression): PyClass? {
 }
 
 fun getPyClassByPyKeywordArgument(pyKeywordArgument: PyKeywordArgument): PyClass? {
-    val pyCallExpression = pyKeywordArgument.parent?.parent as? PyCallExpression ?: return null
+    val pyCallExpression = PsiTreeUtil.getParentOfType(pyKeywordArgument, PyCallExpression::class.java) ?: return null
     return getPyClassByPyCallExpression(pyCallExpression)
 }
 

--- a/src/com/koxudaxi/pydantic/PydanticCompletionContributor.kt
+++ b/src/com/koxudaxi/pydantic/PydanticCompletionContributor.kt
@@ -33,7 +33,7 @@ class PydanticCompletionContributor : CompletionContributor() {
 
             if (!isPydanticModel(pyClass, typeEvalContext)) return
 
-            val definedList = parameters.position.parent.parent.children. mapNotNull {
+            val definedSet = parameters.position.parent.parent.children.mapNotNull {
                 (it as? PyKeywordArgument)?.name
             }.toHashSet()
 
@@ -42,15 +42,15 @@ class PydanticCompletionContributor : CompletionContributor() {
             pyClass.getAncestorClasses(typeEvalContext).filter {
                 isPydanticModel(it) && !isPydanticBaseModel(it)
             }.forEach {
-                addFieldElement(it, definedList, newElements, typeEvalContext)
+                addFieldElement(it, definedSet, newElements, typeEvalContext)
             }
 
-            addFieldElement(pyClass, definedList, newElements, typeEvalContext)
+            addFieldElement(pyClass, definedSet, newElements, typeEvalContext)
 
             result.runRemainingContributors(parameters)
             {
                 val name = it.lookupElement.lookupString
-                if (!newElements.containsKey(name) && !definedList.contains(name)) {
+                if (!newElements.containsKey(name) && !definedSet.contains(name)) {
                     result.passResult(it)
                 }
             }

--- a/src/com/koxudaxi/pydantic/PydanticCompletionContributor.kt
+++ b/src/com/koxudaxi/pydantic/PydanticCompletionContributor.kt
@@ -33,9 +33,10 @@ class PydanticCompletionContributor : CompletionContributor() {
 
             if (!isPydanticModel(pyClass, typeEvalContext)) return
 
-            val definedSet = parameters.position.parent.parent.children.mapNotNull {
-                (it as? PyKeywordArgument)?.name
-            }.toHashSet()
+            val definedSet = parameters.position.parent.parent.children
+                    .mapNotNull { (it as? PyKeywordArgument)?.name }
+                    .map { "${it}=" }
+                    .toHashSet()
 
             val newElements: HashMap<String, LookupElement> = HashMap()
 
@@ -62,15 +63,17 @@ class PydanticCompletionContributor : CompletionContributor() {
                     .asReversed()
                     .asSequence()
                     .filterNot { PyTypingTypeProvider.isClassVar(it, typeEvalContext) }
-                    .filter { it.name != null && !excludes.contains(it.name!!) }
+                    .filter { it.name != null }
                     .forEach {
-                        val className = pyClass.qualifiedName ?: pyClass.name
                         val elementName = "${it.name!!}="
-                        val element = PrioritizedLookupElement.withGrouping(
-                                LookupElementBuilder
-                                        .createWithSmartPointer(elementName, it)
-                                        .withTypeText(className).withIcon(AllIcons.Nodes.Parameter), 1)
-                        results[elementName] = PrioritizedLookupElement.withPriority(element, 100.0)
+                        if (!excludes.contains(elementName)) {
+                            val className = pyClass.qualifiedName ?: pyClass.name
+                            val element = PrioritizedLookupElement.withGrouping(
+                                    LookupElementBuilder
+                                            .createWithSmartPointer(elementName, it)
+                                            .withTypeText(className).withIcon(AllIcons.Nodes.Parameter), 1)
+                            results[elementName] = PrioritizedLookupElement.withPriority(element, 100.0)
+                        }
                     }
         }
     }

--- a/src/com/koxudaxi/pydantic/PydanticCompletionContributor.kt
+++ b/src/com/koxudaxi/pydantic/PydanticCompletionContributor.kt
@@ -1,0 +1,78 @@
+package com.koxudaxi.pydantic
+
+import com.intellij.codeInsight.completion.*
+import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.icons.AllIcons
+import com.intellij.patterns.PlatformPatterns.psiElement
+import com.intellij.util.ProcessingContext
+import com.jetbrains.python.PythonLanguage
+import com.jetbrains.python.codeInsight.completion.getTypeEvalContext
+import com.jetbrains.python.codeInsight.typing.PyTypingTypeProvider
+import com.jetbrains.python.psi.PyCallExpression
+import com.jetbrains.python.psi.PyClass
+import com.jetbrains.python.psi.PyKeywordArgument
+import com.jetbrains.python.psi.types.TypeEvalContext
+
+class PydanticCompletionContributor : CompletionContributor() {
+    init {
+        extend(CompletionType.BASIC,
+                psiElement()
+                        .withLanguage(PythonLanguage.getInstance())
+                        .and(psiElement().inside(PyCallExpression::class.java)),
+                KeywordArgumentCompletionProvider)
+    }
+
+    private object KeywordArgumentCompletionProvider : CompletionProvider<CompletionParameters>() {
+
+        override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
+            val pyCallExpression = parameters.position.parent?.parent?.parent as? PyCallExpression ?: return
+            if (parameters.position.parent?.parent is PyKeywordArgument) return
+            val pyClass = getPyClassByPyCallExpression(pyCallExpression) ?: return
+            val typeEvalContext = parameters.getTypeEvalContext()
+
+            if (!isPydanticModel(pyClass, typeEvalContext)) return
+
+            val definedList = parameters.position.parent.parent.children. mapNotNull {
+                (it as? PyKeywordArgument)?.name
+            }.toHashSet()
+
+            val newElements: HashMap<String, LookupElement> = HashMap()
+
+            pyClass.getAncestorClasses(typeEvalContext).filter {
+                isPydanticModel(it) && !isPydanticBaseModel(it)
+            }.forEach {
+                addFieldElement(it, definedList, newElements, typeEvalContext)
+            }
+
+            addFieldElement(pyClass, definedList, newElements, typeEvalContext)
+
+            result.runRemainingContributors(parameters)
+            {
+                val name = it.lookupElement.lookupString
+                if (!newElements.containsKey(name) && !definedList.contains(name)) {
+                    result.passResult(it)
+                }
+            }
+            result.addAllElements(newElements.values)
+        }
+
+        private fun addFieldElement(pyClass: PyClass, excludes: HashSet<String>, results: HashMap<String, LookupElement>, typeEvalContext: TypeEvalContext) {
+            pyClass.classAttributes
+                    .asReversed()
+                    .asSequence()
+                    .filterNot { PyTypingTypeProvider.isClassVar(it, typeEvalContext) }
+                    .filter { it.name != null && !excludes.contains(it.name!!) }
+                    .forEach {
+                        val className = pyClass.qualifiedName ?: pyClass.name
+                        val elementName = "${it.name!!}="
+                        val element = PrioritizedLookupElement.withGrouping(
+                                LookupElementBuilder
+                                        .createWithSmartPointer(elementName, it)
+                                        .withTypeText(className).withIcon(AllIcons.Nodes.Parameter), 1)
+                        results[elementName] = PrioritizedLookupElement.withPriority(element, 100.0)
+                    }
+        }
+    }
+
+}

--- a/testData/completion/keywordArgument.py
+++ b/testData/completion/keywordArgument.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel
+
+
+class A(BaseModel):
+    abc: str
+    cde: str
+    efg: str
+
+class B(A):
+    hij: str
+
+A(<caret>)

--- a/testData/completion/keywordArgumentAssignValue.py
+++ b/testData/completion/keywordArgumentAssignValue.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+
+class A(BaseModel):
+    abc: str
+    cde: str
+    efg: str
+
+
+A(abc=<caret>)

--- a/testData/completion/keywordArgumentInserted.py
+++ b/testData/completion/keywordArgumentInserted.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+
+class A(BaseModel):
+    abc: str
+    cde: str
+    efg: str
+
+
+A(abc='abc',<caret>)

--- a/testData/completion/keywordArgumentParent.py
+++ b/testData/completion/keywordArgumentParent.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+class A(BaseModel):
+    abc: str
+    cde: str
+
+class B(A):
+    efg: str
+
+B(<caret>)

--- a/testData/completion/keywordArgumentPythonClass.py
+++ b/testData/completion/keywordArgumentPythonClass.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel
+
+
+class A:
+    abc: str
+    cde: str
+    efg: str
+
+A(<caret>)

--- a/testData/completion/keywordArgumentPythonFunction.py
+++ b/testData/completion/keywordArgumentPythonFunction.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+
+def a(
+    abc: str,
+    cde: str,
+    efg: str,
+): pass
+
+a(<caret>)

--- a/testSrc/com/koxudaxi/pydantic/PydanticCompletionTest.kt
+++ b/testSrc/com/koxudaxi/pydantic/PydanticCompletionTest.kt
@@ -13,7 +13,7 @@ open class PydanticCompletionTest : PydanticTestCase() {
         val actual = myFixture!!.completeBasic().filter {
             it!!.psiElement is PyTargetExpression
         }.mapNotNull {
-            it!!.psiElement!!.text
+            it!!.lookupString
         }
         assertEquals(fieldNames, actual)
     }
@@ -21,9 +21,9 @@ open class PydanticCompletionTest : PydanticTestCase() {
     fun testKeywordArgument() {
         doFieldTest(
                 listOf(
-                        "abc",
-                        "cde",
-                        "efg"
+                        "abc=",
+                        "cde=",
+                        "efg="
                 )
         )
     }
@@ -31,9 +31,9 @@ open class PydanticCompletionTest : PydanticTestCase() {
     fun testKeywordArgumentParent() {
         doFieldTest(
                 listOf(
-                        "abc",
-                        "cde",
-                        "efg"
+                        "abc=",
+                        "cde=",
+                        "efg="
                 )
         )
     }
@@ -41,8 +41,8 @@ open class PydanticCompletionTest : PydanticTestCase() {
     fun testKeywordArgumentInserted() {
         doFieldTest(
                 listOf(
-                        "cde",
-                        "efg"
+                        "cde=",
+                        "efg="
                 )
         )
     }

--- a/testSrc/com/koxudaxi/pydantic/PydanticCompletionTest.kt
+++ b/testSrc/com/koxudaxi/pydantic/PydanticCompletionTest.kt
@@ -1,0 +1,70 @@
+package com.koxudaxi.pydantic
+
+import com.jetbrains.python.psi.PyTargetExpression
+
+
+open class PydanticCompletionTest : PydanticTestCase() {
+
+
+    private fun doFieldTest(fieldNames: List<String>) {
+        configureByFile()
+
+
+        val actual = myFixture!!.completeBasic().filter {
+            it!!.psiElement is PyTargetExpression
+        }.mapNotNull {
+            it!!.psiElement!!.text
+        }
+        assertEquals(fieldNames, actual)
+    }
+
+    fun testKeywordArgument() {
+        doFieldTest(
+                listOf(
+                        "abc",
+                        "cde",
+                        "efg"
+                )
+        )
+    }
+
+    fun testKeywordArgumentParent() {
+        doFieldTest(
+                listOf(
+                        "abc",
+                        "cde",
+                        "efg"
+                )
+        )
+    }
+
+    fun testKeywordArgumentInserted() {
+        doFieldTest(
+                listOf(
+                        "cde",
+                        "efg"
+                )
+        )
+    }
+
+    fun testKeywordArgumentAssignValue() {
+        doFieldTest(
+                listOf(
+                )
+        )
+    }
+
+    fun testKeywordArgumentPythonClass() {
+        doFieldTest(
+                listOf(
+                )
+        )
+    }
+
+    fun testKeywordArgumentPythonFunction() {
+        doFieldTest(
+                listOf(
+                )
+        )
+    }
+}


### PR DESCRIPTION
## Detail
The PR appends two features to improve autocompletion for signatures subclasses of pydantic.BaseModel and pydantic.dataclasses.dataclass.

### Features
- Priority showing the fields
 If you enter `Ctr + Space`  or `Cmd + Space` on model Callers then,  Fields are shown on top.
 eg: `Model(<here>)`
- Display definition Class
 The information appears right side on the autocompletion list.

## ScreenShots
![ss2019-08-27 12 21 37](https://user-images.githubusercontent.com/630670/63739960-2c147d00-c8ca-11e9-95cb-cdd3b9c5ed44.png)
