### PR TITLE
Use parsed type for completion

### DIFF
--- a/testData/completion/assignedInstance.py
+++ b/testData/completion/assignedInstance.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 
 class A(BaseModel):
     abc: str
-    cde: str = str('abc')
+    cde = str('abc')
     efg: str = str('abc')
 
 class B(A):

--- a/testData/completion/assignedInstancePythonClass.py
+++ b/testData/completion/assignedInstancePythonClass.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 
 class A:
     abc: str
-    cde: str = str('abc')
+    cde = str('abc')
     efg: str = str('abc')
 
 class B(A):

--- a/testData/completion/class.py
+++ b/testData/completion/class.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 
 class A(BaseModel):
     abc: str
-    cde: str = str('abc')
+    cde = str('abc')
     efg: str = str('abc')
 
 class B(A):

--- a/testData/completion/field.py
+++ b/testData/completion/field.py
@@ -1,0 +1,13 @@
+from builtins import *
+from pydantic import BaseModel
+
+
+class A(BaseModel):
+    abc: str
+    cde = str('abc')
+    efg: str = str('abc')
+
+class B(A):
+    hij: str
+
+A().<caret>

--- a/testData/completion/field.py
+++ b/testData/completion/field.py
@@ -5,9 +5,9 @@ from pydantic import BaseModel
 class A(BaseModel):
     abc: str
     cde = str('abc')
-    efg: str = str('abc')
+    efg: str = ...
 
 class B(A):
     hij: str
 
-A().<caret>
+A.<caret>

--- a/testData/completion/field.py
+++ b/testData/completion/field.py
@@ -6,8 +6,9 @@ class A(BaseModel):
     abc: str
     cde = str('abc')
     efg: str = ...
+    hij = ...
 
 class B(A):
     hij: str
 
-A.<caret>
+A().<caret>

--- a/testData/completion/fieldOptional.py
+++ b/testData/completion/fieldOptional.py
@@ -1,0 +1,15 @@
+from builtins import *
+from typing import Union
+
+from pydantic import BaseModel
+
+
+class A(BaseModel):
+    abc: Union[str, int]
+    cde = str('abc')
+    efg: str = str('abc')
+
+class B(A):
+    hij: str
+
+A.<caret>

--- a/testData/completion/fieldOptional.py
+++ b/testData/completion/fieldOptional.py
@@ -12,4 +12,4 @@ class A(BaseModel):
 class B(A):
     hij: str
 
-A.<caret>
+A().<caret>

--- a/testData/completion/fieldOptional.py
+++ b/testData/completion/fieldOptional.py
@@ -1,11 +1,11 @@
 from builtins import *
-from typing import Union
+from typing import Union, Optional
 
 from pydantic import BaseModel
 
 
 class A(BaseModel):
-    abc: Union[str, int]
+    abc: Optional[str]
     cde = str('abc')
     efg: str = str('abc')
 

--- a/testData/completion/fieldSchema.py
+++ b/testData/completion/fieldSchema.py
@@ -5,8 +5,9 @@ class A(BaseModel):
     abc: str = Schema(...)
     cde = Schema(str('abc'))
     efg = Schema(default=str('abc'))
+    hij = Schema(default=...)
 
 class B(A):
     hij: str
 
-A.<caret>
+A().<caret>

--- a/testData/completion/fieldSchema.py
+++ b/testData/completion/fieldSchema.py
@@ -1,0 +1,13 @@
+from builtins import *
+from pydantic import BaseModel
+
+
+class A(BaseModel):
+    abc: str
+    cde = str('abc')
+    efg: str = str('abc')
+
+class B(A):
+    hij: str
+
+A.<caret>

--- a/testData/completion/fieldSchema.py
+++ b/testData/completion/fieldSchema.py
@@ -1,11 +1,10 @@
 from builtins import *
-from pydantic import BaseModel
-
+from pydantic import BaseModel, Schema
 
 class A(BaseModel):
-    abc: str
-    cde = str('abc')
-    efg: str = str('abc')
+    abc: str = Schema(...)
+    cde = Schema(str('abc'))
+    efg = Schema(default=str('abc'))
 
 class B(A):
     hij: str

--- a/testData/completion/fieldUnion.py
+++ b/testData/completion/fieldUnion.py
@@ -1,0 +1,13 @@
+from builtins import *
+from pydantic import BaseModel
+
+
+class A(BaseModel):
+    abc: str
+    cde = str('abc')
+    efg: str = str('abc')
+
+class B(A):
+    hij: str
+
+A.<caret>

--- a/testData/completion/fieldUnion.py
+++ b/testData/completion/fieldUnion.py
@@ -12,4 +12,4 @@ class A(BaseModel):
 class B(A):
     hij: str
 
-A.<caret>
+A().<caret>

--- a/testData/completion/fieldUnion.py
+++ b/testData/completion/fieldUnion.py
@@ -1,10 +1,12 @@
 from builtins import *
+from typing import Union
+
 from pydantic import BaseModel
 
 
 class A(BaseModel):
-    abc: str
-    cde = str('abc')
+    abc: Union[str, int]
+    cde: Union[str, int] = ...
     efg: str = str('abc')
 
 class B(A):

--- a/testData/completion/instance.py
+++ b/testData/completion/instance.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 
 class A(BaseModel):
     abc: str
-    cde: str = str('abc')
+    cde = str('abc')
     efg: str = str('abc')
 
 class B(A):

--- a/testSrc/com/koxudaxi/pydantic/PydanticCompletionTest.kt
+++ b/testSrc/com/koxudaxi/pydantic/PydanticCompletionTest.kt
@@ -292,6 +292,7 @@ open class PydanticCompletionTest : PydanticTestCase() {
                         Pair("abc", "str A"),
                         Pair("cde", "str=str('abc') A"),
                         Pair("efg", "str=... A"),
+                        Pair("hij", "Any=... A"),
                         Pair("___slots__", "BaseModel")
                 )
         )
@@ -325,6 +326,7 @@ open class PydanticCompletionTest : PydanticTestCase() {
                         Pair("abc", "str=Schema(...) A"),
                         Pair("cde", "str=Schema(str('abc')) A"),
                         Pair("efg", "str=Schema(default=str('abc')) A"),
+                        Pair("hij", "Any=Schema(default=...) A"),
                         Pair("___slots__", "BaseModel")
                 )
         )

--- a/testSrc/com/koxudaxi/pydantic/PydanticCompletionTest.kt
+++ b/testSrc/com/koxudaxi/pydantic/PydanticCompletionTest.kt
@@ -285,4 +285,48 @@ open class PydanticCompletionTest : PydanticTestCase() {
                 )
         )
     }
+
+    fun testField() {
+        doFieldTest(
+                listOf(
+                        Pair("abc", "str A"),
+                        Pair("cde", "str=str('abc') A"),
+                        Pair("efg", "str=... A"),
+                        Pair("___slots__", "BaseModel")
+                )
+        )
+    }
+
+    fun testFieldOptional() {
+        doFieldTest(
+                listOf(
+                        Pair("abc", "Optional[str] A"),
+                        Pair("cde", "str=str('abc') A"),
+                        Pair("efg", "str=str('abc') A"),
+                        Pair("___slots__", "BaseModel")
+                )
+        )
+    }
+
+    fun testFieldUnion() {
+        doFieldTest(
+                listOf(
+                        Pair("abc", "Union[str, int] A"),
+                        Pair("cde", "Union[str, int]=... A"),
+                        Pair("efg", "str=str('abc') A"),
+                        Pair("___slots__", "BaseModel")
+                )
+        )
+    }
+
+    fun testFieldSchema() {
+        doFieldTest(
+                listOf(
+                        Pair("abc", "str=Schema(...) A"),
+                        Pair("cde", "str=Schema(str('abc')) A"),
+                        Pair("efg", "str=Schema(default=str('abc')) A"),
+                        Pair("___slots__", "BaseModel")
+                )
+        )
+    }
 }


### PR DESCRIPTION
The PR supports to show parsed types for fields completion.
The is a small feature. And the PR cover few cases. 
eg: 
```
class A(BaseModel):
  item = Schema('apple')

a = A(item='orange')
a.item # auto-completion show type as str