### PR TITLE
remove fields on auto-completion of subclasses of pydantic.BaseModel …

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -7,6 +7,7 @@
     <h2>version 0.0.16</h2>
     <p>Features, BugFixes</p>
     <ul>
+        <li>remove fields on auto-completion of subclasses of pydantic.BaseModel and pydantic.dataclasses.dataclass [#61] </li>
         <li>Change default value "..." to None on auto-completion [#60] </li>
         <li>Add types and default values to popup of auto-completion [#54] </li>
         <li>Fix class imported path on auto-completion [#54] </li>

--- a/src/com/koxudaxi/pydantic/PydanticCompletionContributor.kt
+++ b/src/com/koxudaxi/pydantic/PydanticCompletionContributor.kt
@@ -141,9 +141,13 @@ class PydanticCompletionContributor : CompletionContributor() {
 
             result.runRemainingContributors(parameters)
             { completionResult ->
-                completionResult.lookupElement.lookupString
-                        .takeIf { name -> !fieldElements.contains(name) && (excludes == null || !excludes.contains(name)) }
-                        ?.let { result.passResult(completionResult) }
+                if (completionResult.lookupElement.psiElement?.getIcon(0) == AllIcons.Nodes.Field ) {
+                    completionResult.lookupElement.lookupString
+                            .takeIf { name -> !fieldElements.contains(name) && (excludes == null || !excludes.contains(name)) }
+                            ?.let { result.passResult(completionResult) }
+                } else {
+                    result.passResult(completionResult)
+                }
             }
         }
     }

--- a/testData/completion/class.py
+++ b/testData/completion/class.py
@@ -1,14 +1,13 @@
 from builtins import *
 from pydantic import BaseModel
 
+class B:
+    hij: str
 
-class A(BaseModel):
+class A(BaseModel, B):
     abc: str
     cde = str('abc')
     efg: str = str('abc')
-
-class B(A):
-    hij: str
 
 
 A.<caret>

--- a/testSrc/com/koxudaxi/pydantic/PydanticCompletionTest.kt
+++ b/testSrc/com/koxudaxi/pydantic/PydanticCompletionTest.kt
@@ -278,9 +278,7 @@ open class PydanticCompletionTest : PydanticTestCase() {
     fun testClass() {
         doFieldTest(
                 listOf(
-                        Pair("abc", "str A"),
-                        Pair("cde", "str=str('abc') A"),
-                        Pair("efg", "str=str('abc') A"),
+                        Pair("hij", "B"),
                         Pair("___slots__", "BaseModel")
                 )
         )

--- a/testSrc/com/koxudaxi/pydantic/PydanticCompletionTest.kt
+++ b/testSrc/com/koxudaxi/pydantic/PydanticCompletionTest.kt
@@ -333,7 +333,6 @@ open class PydanticCompletionTest : PydanticTestCase() {
     fun testClassMethodCls() {
         doFieldTest(
                 listOf(
-                        Pair("abc", "str A"),
                         Pair("___slots__", "BaseModel")
                 )
         )


### PR DESCRIPTION
The PR removes fields on auto-completion which is subclasses of pydantic.BaseModel and pydantic.dataclasses.dataclass.
A real class does not have fields as class attributes. 
The fields appear on an instance.
However, auto-completion show fields as class attributes.

eg:
```python
class A(BaseModel):
  abc: str = None

A.abc  # invalid
A().abc # corret

```