### PR TITLE
Fix removing python class fields on auto-completion

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -5,7 +5,7 @@
     <vendor email="koaxudai@gmail.com">Koudai Aono @koxudaxi</vendor>
     <change-notes><![CDATA[
     <h2>version 0.0.17</h2>
-    <p>Features, BugFixes</p>
+    <p>BugFixes</p>
     <ul>
         <li>Fix removing fields on non-subclasses of pydantic.BaseModel and pydantic.dataclasses.dataclass [#62] </li>
     </ul>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,9 +1,14 @@
 <idea-plugin url="https://github.com/koxudaxi/pydantic-pycharm-plugin">
     <id>com.koxudaxi.pydantic</id>
     <name>Pydantic</name>
-    <version>0.0.16</version>
+    <version>0.0.17</version>
     <vendor email="koaxudai@gmail.com">Koudai Aono @koxudaxi</vendor>
     <change-notes><![CDATA[
+    <h2>version 0.0.17</h2>
+    <p>Features, BugFixes</p>
+    <ul>
+        <li>Fix removing fields on non-subclasses of pydantic.BaseModel and pydantic.dataclasses.dataclass [#62] </li>
+    </ul>
     <h2>version 0.0.16</h2>
     <p>Features, BugFixes</p>
     <ul>

--- a/src/com/koxudaxi/pydantic/PydanticCompletionContributor.kt
+++ b/src/com/koxudaxi/pydantic/PydanticCompletionContributor.kt
@@ -142,6 +142,8 @@ class PydanticCompletionContributor : CompletionContributor() {
                                          pyClass: PyClass, typeEvalContext: TypeEvalContext,
                                          excludes: HashSet<String>? = null) {
 
+            if (!isPydanticModel(pyClass)) return
+
             val fieldElements: HashSet<String> = HashSet()
 
             pyClass.getAncestorClasses(typeEvalContext)

--- a/testData/completion/pythonClass.py
+++ b/testData/completion/pythonClass.py
@@ -1,0 +1,13 @@
+from builtins import *
+from pydantic import BaseModel
+
+class B:
+    hij: str
+
+class A:
+    abc: str
+    cde: str
+    efg: str
+
+
+A.<caret>

--- a/testSrc/com/koxudaxi/pydantic/PydanticCompletionTest.kt
+++ b/testSrc/com/koxudaxi/pydantic/PydanticCompletionTest.kt
@@ -284,6 +284,16 @@ open class PydanticCompletionTest : PydanticTestCase() {
         )
     }
 
+    fun testPythonClass() {
+        doFieldTest(
+                listOf(
+                        Pair("abc", "A"),
+                        Pair("cde", "A"),
+                        Pair("efg", "A")
+                )
+        )
+    }
+
     fun testField() {
         doFieldTest(
                 listOf(


### PR DESCRIPTION
The PR fixes removing python class fields on auto-completion.
The plugin removes fields on auto-completion when reference subclass of pydantic.BaseModel and pydantic.dataclasses.dataclass.
However, a bug works on any class.
 It means we can't see class attributes of any class on auto-completion.

