### PR TITLE
fix wrong warning message for cls initialization

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,9 +1,14 @@
 <idea-plugin url="https://github.com/koxudaxi/pydantic-pycharm-plugin">
     <id>com.koxudaxi.pydantic</id>
     <name>Pydantic</name>
-    <version>0.0.18</version>
+    <version>0.0.19</version>
     <vendor email="koaxudai@gmail.com">Koudai Aono @koxudaxi</vendor>
     <change-notes><![CDATA[
+    <h2>version 0.0.19</h2>
+    <p>Features</p>
+    <ul>
+        <li>Fix wrong warning message for cls initialization [#66] </li>
+    </ul>
     <h2>version 0.0.18</h2>
     <p>Features</p>
     <ul>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -5,7 +5,7 @@
     <vendor email="koaxudai@gmail.com">Koudai Aono @koxudaxi</vendor>
     <change-notes><![CDATA[
     <h2>version 0.0.19</h2>
-    <p>Features</p>
+    <p>BugFixes</p>
     <ul>
         <li>Fix wrong warning message for cls initialization [#66] </li>
     </ul>

--- a/src/com/koxudaxi/pydantic/PydanticTypeProvider.kt
+++ b/src/com/koxudaxi/pydantic/PydanticTypeProvider.kt
@@ -83,6 +83,7 @@ class PydanticTypeProvider : PyTypeProviderBase() {
     }
 
     private fun getPydanticTypeForClass(pyClass: PyClass, context: TypeEvalContext): PyCallableType? {
+        if (!isPydanticModel(pyClass, context)) return null
         val clsType = (context.getType(pyClass) as? PyClassLikeType) ?: return null
         val ellipsis = PyElementGenerator.getInstance(pyClass.project).createEllipsis()
         val resolveContext = PyResolveContext.noImplicits().withTypeEvalContext(context)


### PR DESCRIPTION
This PR fixes wrong warning message for `cls` initialization.

I have added code to check whether the type of `cls` is pydantic model 

## Related Issues
https://github.com/koxudaxi/pydantic-pycharm-plugin/issues/65