### PR TITLE
fix auto completion for Fields

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -4,6 +4,12 @@
     <version>0.0.21</version>
     <vendor email="koaxudai@gmail.com">Koudai Aono @koxudaxi</vendor>
     <change-notes><![CDATA[
+    <h2>version 0.0.22</h2>
+    <p>Features, BugFixes</p>
+    <ul>
+        <li>Fix auto-completion for Fields [#75] </li>
+        <li>Improve to insert validate methods [#74] </li>
+    </ul>
     <h2>version 0.0.21</h2>
     <p>Features, BugFixes</p>
     <ul>

--- a/src/com/koxudaxi/pydantic/PydanticCompletionContributor.kt
+++ b/src/com/koxudaxi/pydantic/PydanticCompletionContributor.kt
@@ -118,7 +118,7 @@ class PydanticCompletionContributor : CompletionContributor() {
             { completionResult ->
                 if (completionResult.lookupElement.psiElement?.getIcon(0) == AllIcons.Nodes.Field) {
                     completionResult.lookupElement.lookupString
-                            .takeIf { name -> !fieldElements.contains(name) && (excludes == null || !excludes.contains(name)) }
+                            .takeIf { name -> !fieldElements.contains(name) && (!excludes.contains(name)) }
                             ?.let { result.passResult(completionResult) }
                 } else {
                     result.passResult(completionResult)
@@ -135,9 +135,9 @@ class PydanticCompletionContributor : CompletionContributor() {
         override val icon: Icon = AllIcons.Nodes.Parameter
 
         override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
-            val pyArgumentList = parameters.position.parent!!.parent!! as PyArgumentList
+            val pyArgumentList = parameters.position.parent?.parent as? PyArgumentList ?: return
             val typeEvalContext = parameters.getTypeEvalContext()
-            val pyClassType = (typeEvalContext.getType(pyArgumentList.parent as PyCallExpression) as? PyClassType)
+            val pyClassType = (pyArgumentList.parent as? PyCallExpression)?.let{typeEvalContext.getType(it)} as? PyClassType
                     ?: return
 
             if (!isPydanticModel(pyClassType.pyClass, typeEvalContext)) return
@@ -160,7 +160,7 @@ class PydanticCompletionContributor : CompletionContributor() {
 
         override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
             val typeEvalContext = parameters.getTypeEvalContext()
-            val pyType = typeEvalContext.getType(parameters.position.parent.firstChild as PyTypedElement) ?: return
+            val pyType = (parameters.position.parent?.firstChild as? PyTypedElement)?.let { typeEvalContext.getType(it)} ?: return
 
             val pyClassType = getPyClassTypeByPyTypes(pyType).firstOrNull { isPydanticModel(it.pyClass) } ?: return
             if (pyClassType.isDefinition) { // class


### PR DESCRIPTION
The PR fixes a bug which fails autocompletion

## How to fix it
The PR uses a safe cast for elements. aka `as?`

## Stack Trace
```
java.lang.ClassCastException: class com.intellij.psi.impl.source.tree.LeafPsiElement cannot be cast to class com.jetbrains.python.psi.PyTypedElement (com.intellij.psi.impl.source.tree.LeafPsiElement and com.jetbrains.python.psi.PyTypedElement are in unnamed module of loader com.intellij.util.lang.UrlClassLoader @5700d6b1)
    at com.koxudaxi.pydantic.PydanticCompletionContributor$FieldCompletionProvider.addCompletions(PydanticCompletionContributor.kt:161)
    at com.intellij.codeInsight.completion.CompletionProvider.addCompletionVariants(CompletionProvider.java:40)
    at com.intellij.codeInsight.completion.CompletionContributor.fillCompletionVariants(CompletionContributor.java:150)
    at com.intellij.codeInsight.completion.CompletionService.getVariantsFromContributors(CompletionService.java:63)
    at com.intellij.codeInsight.completion.CompletionResultSet.runRemainingContributors(CompletionResultSet.java:148)
    at com.intellij.codeInsight.completion.CompletionResultSet.runRemainingContributors(CompletionResultSet.java:141)
    at com.intellij.codeInsight.template.impl.LiveTemplateCompletionContributor$1.addCompletions(LiveTemplateCompletionContributor.java:77)
    at com.intellij.codeInsight.completion.CompletionProvider.addCompletionVariants(CompletionProvider.java:40)
    at com.intellij.codeInsight.completion.CompletionContributor.fillCompletionVariants(CompletionContributor.java:150)
    at com.intellij.codeInsight.completion.CompletionService.getVariantsFromContributors(CompletionService.java:63)
    at com.intellij.codeInsight.completion.CompletionService.performCompletion(CompletionService.java:119)
    at com.intellij.codeInsight.completion.impl.CompletionServiceImpl.performCompletion(CompletionServiceImpl.java:55)
    at com.intellij.codeInsight.completion.CompletionProgressIndicator.calculateItems(CompletionProgressIndicator.java:824)
    at com.intellij.codeInsight.completion.CompletionProgressIndicator.runContributors(CompletionProgressIndicator.java:809)
    at com.intellij.codeInsight.completion.CodeCompletionHandlerBase.lambda$null$5(CodeCompletionHandlerBase.java:325)
    at com.intellij.codeInsight.completion.AsyncCompletion.lambda$tryReadOrCancel$5(CompletionThreading.java:172)
    at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1106)
    at com.intellij.codeInsight.completion.AsyncCompletion.tryReadOrCancel(CompletionThreading.java:170)
    at com.intellij.codeInsight.completion.CodeCompletionHandlerBase.lambda$startContributorThread$6(CodeCompletionHandlerBase.java:317)
    at com.intellij.codeInsight.completion.AsyncCompletion.lambda$null$0(CompletionThreading.java:95)
    at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$2(CoreProgressManager.java:169)
    at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:591)
    at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:537)
    at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:59)
    at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:156)
    at com.intellij.codeInsight.completion.AsyncCompletion.lambda$startThread$1(CompletionThreading.java:91)
    at com.intellij.openapi.application.impl.ApplicationImpl$1.run(ApplicationImpl.java:294)
    at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
    at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
    at java.base/java.lang.Thread.run(Thread.java:834)
```