### PR TITLE
Fix fisrt parameter type of a validator method

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -7,6 +7,7 @@
     <h2>version 0.0.22</h2>
     <p>Features, BugFixes</p>
     <ul>
+        <li>Fix first parameter type of a validator method [#76] </li>
         <li>Fix auto-completion for Fields [#75] </li>
         <li>Improve to insert validate methods [#74] </li>
     </ul>

--- a/testData/completion/classValidatorCls.py
+++ b/testData/completion/classValidatorCls.py
@@ -1,0 +1,13 @@
+,from builtins import *
+
+from pydantic import BaseModel, validator
+
+
+class A(BaseModel):
+    abc: str
+
+    @validator('abc')
+    def test(cls):
+        return cls.<caret>
+
+

--- a/testSrc/com/koxudaxi/pydantic/PydanticCompletionTest.kt
+++ b/testSrc/com/koxudaxi/pydantic/PydanticCompletionTest.kt
@@ -431,6 +431,14 @@ open class PydanticCompletionTest : PydanticTestCase() {
         )
     }
 
+    fun testClassValidatorCls() {
+        doFieldTest(
+                listOf(
+                        Pair("___slots__", "BaseModel")
+                )
+        )
+    }
+
     fun testMethodSelf() {
         doFieldTest(
                 listOf(


### PR DESCRIPTION
The PRs fixes first parameter type of a validator method.
The type of parameter should be `Class`.

eg:
```
class Model(BaseModel):
    bar: int


    @validator('bar')
    def fa(cls, bar):
        cls  # <- cls is Class
```