### PR TITLE
Add auto-completion for config fields

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -7,7 +7,8 @@
     <h2>version 0.0.25</h2>
     <p>Features</p>
     <ul>
-        <li>support allow_population_by_field_name [#82] </li>
+        <li>Add auto-completion for config fields [#84] </li>
+        <li>Support allow_population_by_field_name [#82] </li>
     </ul>
     <h2>version 0.0.24</h2>
     <p>BugFixes</p>

--- a/src/com/koxudaxi/pydantic/PydanticCompletionContributor.kt
+++ b/src/com/koxudaxi/pydantic/PydanticCompletionContributor.kt
@@ -4,6 +4,7 @@ import com.intellij.codeInsight.completion.*
 import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.icons.AllIcons
+import com.intellij.openapi.project.Project
 import com.intellij.patterns.PlatformPatterns.psiElement
 import com.intellij.util.ProcessingContext
 import com.jetbrains.python.PyTokenTypes
@@ -28,6 +29,15 @@ class PydanticCompletionContributor : CompletionContributor() {
                         .afterLeaf(psiElement(PyTokenTypes.DOT))
                         .withParent(psiElement(PyReferenceExpression::class.java)),
                 FieldCompletionProvider)
+        extend(CompletionType.BASIC,
+                psiElement(PyTokenTypes.IDENTIFIER).withParents(
+                        PyReferenceExpression::class.java,
+                        PyExpressionStatement::class.java,
+                        PyStatementList::class.java,
+                        PyClass::class.java,
+                        PyStatementList::class.java,
+                        PyClass::class.java),
+                ConfigCompletionProvider)
     }
 
     private abstract class PydanticCompletionProvider : CompletionProvider<CompletionParameters>() {
@@ -185,4 +195,58 @@ class PydanticCompletionContributor : CompletionContributor() {
             addAllFieldElement(parameters, result, pyClassType.pyClass, typeEvalContext, ellipsis, config)
         }
     }
+
+    private object ConfigCompletionProvider : PydanticCompletionProvider() {
+        override fun getLookupNameFromFieldName(field: PyTargetExpression, context: TypeEvalContext, pydanticVersion: KotlinVersion?, config: HashMap<String, String?>): String {
+            return "${getFieldName(field, context, config, pydanticVersion)}="
+        }
+
+        override val icon: Icon = AllIcons.Nodes.Field
+
+        private fun getConfigAttributeAllElements(configClass: PyClass,
+                                    typeEvalContext: TypeEvalContext,
+                                    excludes: HashSet<String>?) : LinkedHashMap<String, LookupElement> {
+
+            val newElements: LinkedHashMap<String, LookupElement> = LinkedHashMap()
+
+            configClass.classAttributes
+                    .asReversed()
+                    .asSequence()
+                    .filter { it.name != null && it.hasAssignedValue() }
+                    .forEach {
+                        val elementName = it.name!!
+                        val assignedValue = it.findAssignedValue()!!
+                        if (excludes == null || !excludes.contains(elementName)) {
+                            val element = PrioritizedLookupElement.withGrouping(
+                                    LookupElementBuilder
+                                            .createWithSmartPointer("$elementName = ${assignedValue.text}", it)
+                                            .withTypeText(configClass.name)
+                                            .withIcon(icon), 1)
+                            newElements[elementName] = PrioritizedLookupElement.withPriority(element, 100.0)
+                        }
+                    }
+            return newElements
+        }
+
+
+        override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
+            val configClass = parameters.position.parent?.parent?.parent?.parent as? PyClass ?: return
+            if (!isConfigClass(configClass)) return
+            val pydanticModel = configClass.parent?.parent as? PyClass ?:return
+            if (!isPydanticModel(pydanticModel)) return
+            val typeEvalContext = parameters.getTypeEvalContext()
+
+            val definedSet = configClass.getClassAttributesInherited(typeEvalContext)
+                    .mapNotNull { it.name }
+                    .toHashSet()
+
+            val project = configClass.project
+            val baseConfig = getPydanticBaseConfig(project, typeEvalContext) ?: return
+
+            val results = getConfigAttributeAllElements(baseConfig, typeEvalContext, definedSet)
+            result.runRemainingContributors(parameters,false)
+            result.addAllElements(results.values)
+        }
+    }
+
 }

--- a/src/com/koxudaxi/pydantic/PydanticCompletionContributor.kt
+++ b/src/com/koxudaxi/pydantic/PydanticCompletionContributor.kt
@@ -236,7 +236,7 @@ class PydanticCompletionContributor : CompletionContributor() {
             if (!isPydanticModel(pydanticModel)) return
             val typeEvalContext = parameters.getTypeEvalContext()
 
-            val definedSet = configClass.getClassAttributesInherited(typeEvalContext)
+            val definedSet = configClass.classAttributes
                     .mapNotNull { it.name }
                     .toHashSet()
 

--- a/src/com/koxudaxi/pydantic/PydanticCompletionContributor.kt
+++ b/src/com/koxudaxi/pydantic/PydanticCompletionContributor.kt
@@ -215,7 +215,6 @@ class PydanticCompletionContributor : CompletionContributor() {
         override val icon: Icon = AllIcons.Nodes.Field
 
         private fun getConfigAttributeAllElements(configClass: PyClass,
-                                    typeEvalContext: TypeEvalContext,
                                     excludes: HashSet<String>?) : LinkedHashMap<String, LookupElement> {
 
             val newElements: LinkedHashMap<String, LookupElement> = LinkedHashMap()
@@ -254,7 +253,7 @@ class PydanticCompletionContributor : CompletionContributor() {
             val project = configClass.project
             val baseConfig = getPydanticBaseConfig(project, typeEvalContext) ?: return
 
-            val results = getConfigAttributeAllElements(baseConfig, typeEvalContext, definedSet)
+            val results = getConfigAttributeAllElements(baseConfig, definedSet)
             result.runRemainingContributors(parameters,false)
             result.addAllElements(results.values)
         }

--- a/testData/completion/config.py
+++ b/testData/completion/config.py
@@ -1,0 +1,6 @@
+from builtins import *
+from pydantic import BaseModel
+
+class A(BaseModel):
+    class Config:
+        A.<caret>

--- a/testData/completion/configDefined.py
+++ b/testData/completion/configDefined.py
@@ -5,4 +5,4 @@ class A(BaseModel):
     class Config:
         allow_population_by_field_name = True
         max_anystr_length = 10
-        A.<caret>
+        <caret>

--- a/testData/completion/configDefined.py
+++ b/testData/completion/configDefined.py
@@ -1,0 +1,8 @@
+from builtins import *
+from pydantic import BaseModel
+
+class A(BaseModel):
+    class Config:
+        allow_population_by_field_name = True
+        max_anystr_length = 10
+        A.<caret>

--- a/testData/completion/definedNestedClass.py
+++ b/testData/completion/definedNestedClass.py
@@ -3,4 +3,5 @@ from pydantic import BaseModel
 
 class A(BaseModel):
     class Config:
-        <caret>
+        pass
+    <caret>

--- a/testData/completion/nestedClass.py
+++ b/testData/completion/nestedClass.py
@@ -2,5 +2,4 @@ from builtins import *
 from pydantic import BaseModel
 
 class A(BaseModel):
-    class Config:
-        <caret>
+    <caret>

--- a/testData/mock/pydanticv1/__init__.py
+++ b/testData/mock/pydanticv1/__init__.py
@@ -1,4 +1,4 @@
-from .main import BaseModel
+from .main import BaseModel, BaseConfig
 from .class_validators import validator, root_validator
 from .fields import Field, Schema
 from .env_settings import BaseSettings

--- a/testData/mock/pydanticv1/main.py
+++ b/testData/mock/pydanticv1/main.py
@@ -3,3 +3,44 @@ class BaseModel:
         pass
 
     ___slots__ = ()
+
+
+class Extra(str):
+    allow = 'allow'
+    ignore = 'ignore'
+    forbid = 'forbid'
+
+class GetterDict:
+    pass
+
+
+class json:
+    def loads(self):
+        pass
+
+    def dumps(self):
+        pass
+
+
+class BaseConfig:
+    title = None
+    anystr_strip_whitespace = False
+    min_anystr_length = None
+    max_anystr_length = None
+    validate_all = False
+    extra = Extra.ignore
+    allow_mutation = True
+    allow_population_by_field_name = False
+    use_enum_values = False
+    fields = {}
+    validate_assignment = False
+    error_msg_templates = {}
+    arbitrary_types_allowed = False
+    orm_mode: bool = False
+    getter_dict = GetterDict
+    alias_generator = None
+    keep_untouched = ()
+    schema_extra = {}
+    json_loads = json.loads
+    json_dumps = json.dumps
+    json_encoders = {}

--- a/testSrc/com/koxudaxi/pydantic/PydanticCompletionTest.kt
+++ b/testSrc/com/koxudaxi/pydantic/PydanticCompletionTest.kt
@@ -375,6 +375,21 @@ open class PydanticCompletionTest : PydanticTestCase() {
         )
     }
 
+//    fun testNestedClass() {
+//        doFieldTest(
+//                listOf(
+//                        Pair("class Config", "null")
+//                )
+//        )
+//    }
+
+    fun testDefinedNestedClass() {
+        doFieldTest(
+                listOf(
+                )
+        )
+    }
+
     fun testPythonClass() {
         doFieldTest(
                 listOf(

--- a/testSrc/com/koxudaxi/pydantic/PydanticCompletionTest.kt
+++ b/testSrc/com/koxudaxi/pydantic/PydanticCompletionTest.kt
@@ -118,10 +118,10 @@ open class PydanticCompletionTest : PydanticTestCase() {
     fun testInstanceBroken() {
         doFieldTest(
                 listOf(
-                    Pair("abc", "str A"),
-                    Pair("cde", "str=s A"),
-                    Pair("efg", "Any A"),
-                    Pair("___slots__", "BaseModel")
+                        Pair("abc", "str A"),
+                        Pair("cde", "str=s A"),
+                        Pair("efg", "Any A"),
+                        Pair("___slots__", "BaseModel")
                 )
         )
     }
@@ -321,6 +321,60 @@ open class PydanticCompletionTest : PydanticTestCase() {
         )
     }
 
+    fun testConfig() {
+        doFieldTest(
+                listOf(
+                        Pair("alias_generator = None", "BaseConfig"),
+                        Pair("allow_mutation = True", "BaseConfig"),
+                        Pair("allow_population_by_field_name = False", "BaseConfig"),
+                        Pair("anystr_strip_whitespace = False", "BaseConfig"),
+                        Pair("arbitrary_types_allowed = False", "BaseConfig"),
+                        Pair("error_msg_templates = {}", "BaseConfig"),
+                        Pair("extra = Extra.ignore", "BaseConfig"),
+                        Pair("fields = {}", "BaseConfig"),
+                        Pair("getter_dict = GetterDict", "BaseConfig"),
+                        Pair("json_dumps = json.dumps", "BaseConfig"),
+                        Pair("json_encoders = {}", "BaseConfig"),
+                        Pair("json_loads = json.loads", "BaseConfig"),
+                        Pair("keep_untouched = ()", "BaseConfig"),
+                        Pair("max_anystr_length = None", "BaseConfig"),
+                        Pair("min_anystr_length = None", "BaseConfig"),
+                        Pair("orm_mode = False", "BaseConfig"),
+                        Pair("schema_extra = {}", "BaseConfig"),
+                        Pair("title = None", "BaseConfig"),
+                        Pair("use_enum_values = False", "BaseConfig"),
+                        Pair("validate_all = False", "BaseConfig"),
+                        Pair("validate_assignment = False", "BaseConfig")
+                )
+        )
+    }
+
+    fun testConfigDefined() {
+        doFieldTest(
+                listOf(
+                        Pair("alias_generator = None", "BaseConfig"),
+                        Pair("allow_mutation = True", "BaseConfig"),
+                        Pair("anystr_strip_whitespace = False", "BaseConfig"),
+                        Pair("arbitrary_types_allowed = False", "BaseConfig"),
+                        Pair("error_msg_templates = {}", "BaseConfig"),
+                        Pair("extra = Extra.ignore", "BaseConfig"),
+                        Pair("fields = {}", "BaseConfig"),
+                        Pair("getter_dict = GetterDict", "BaseConfig"),
+                        Pair("json_dumps = json.dumps", "BaseConfig"),
+                        Pair("json_encoders = {}", "BaseConfig"),
+                        Pair("json_loads = json.loads", "BaseConfig"),
+                        Pair("keep_untouched = ()", "BaseConfig"),
+                        Pair("min_anystr_length = None", "BaseConfig"),
+                        Pair("orm_mode = False", "BaseConfig"),
+                        Pair("schema_extra = {}", "BaseConfig"),
+                        Pair("title = None", "BaseConfig"),
+                        Pair("use_enum_values = False", "BaseConfig"),
+                        Pair("validate_all = False", "BaseConfig"),
+                        Pair("validate_assignment = False", "BaseConfig")
+                )
+        )
+    }
+
     fun testPythonClass() {
         doFieldTest(
                 listOf(
@@ -384,10 +438,10 @@ open class PydanticCompletionTest : PydanticTestCase() {
     fun testFieldSchema() {
         doFieldTest(
                 listOf(
-                        Pair("a_id","str A"),
+                        Pair("a_id", "str A"),
                         Pair("abc", "str A"),
-                        Pair("b_id","str A"),
-                        Pair("c_id","str A"),
+                        Pair("b_id", "str A"),
+                        Pair("c_id", "str A"),
                         Pair("cde", "str=str('abc') A"),
                         Pair("d_id", "str A"),
                         Pair("e_id", "str A"),
@@ -403,10 +457,10 @@ open class PydanticCompletionTest : PydanticTestCase() {
     fun testFieldSchemaField() {
         doFieldTest(
                 listOf(
-                        Pair("a_id","str A"),
+                        Pair("a_id", "str A"),
                         Pair("abc", "str A"),
-                        Pair("b_id","str A"),
-                        Pair("c_id","str A"),
+                        Pair("b_id", "str A"),
+                        Pair("c_id", "str A"),
                         Pair("cde", "str=str('abc') A"),
                         Pair("d_id", "str A"),
                         Pair("e_id", "str A"),
@@ -422,10 +476,10 @@ open class PydanticCompletionTest : PydanticTestCase() {
     fun testFieldField() {
         doFieldTest(
                 listOf(
-                        Pair("a_id","str A"),
+                        Pair("a_id", "str A"),
                         Pair("abc", "str A"),
-                        Pair("b_id","str A"),
-                        Pair("c_id","str A"),
+                        Pair("b_id", "str A"),
+                        Pair("c_id", "str A"),
                         Pair("cde", "str=str('abc') A"),
                         Pair("d_id", "str A"),
                         Pair("e_id", "str A"),
@@ -481,6 +535,7 @@ open class PydanticCompletionTest : PydanticTestCase() {
                 )
         )
     }
+
     fun testKeywordArgumentSchemaField() {
         doFieldTest(
                 listOf(


### PR DESCRIPTION
The PR adds auto-completion for config fields.
The files come from `pydantic.BaseConfig`

## Related issues
https://github.com/koxudaxi/pydantic-pycharm-plugin/issues/83