### PR TITLE
Support to inspect read-only property

### DIFF
--- a/src/com/koxudaxi/pydantic/Pydantic.kt
+++ b/src/com/koxudaxi/pydantic/Pydantic.kt
@@ -44,13 +44,15 @@ val pydanticVersionCache: HashMap<String, KotlinVersion> = hashMapOf()
 val DEFAULT_CONFIG = mapOf<String, Any?>(
         "allow_population_by_alias" to false,
         "allow_population_by_field_name" to false,
-        "orm_mode" to false
+        "orm_mode" to false,
+        "allow_mutation" to true
 )
 
 val CONFIG_TYPES = mapOf(
         "allow_population_by_alias" to Boolean,
         "allow_population_by_field_name" to Boolean,
-        "orm_mode" to Boolean
+        "orm_mode" to Boolean,
+        "allow_mutation" to Boolean
 )
 
 internal fun getPyClassByPyCallExpression(pyCallExpression: PyCallExpression, context: TypeEvalContext): PyClass? {

--- a/testData/inspection/readOnlyProperty.py
+++ b/testData/inspection/readOnlyProperty.py
@@ -1,0 +1,41 @@
+from pydantic import BaseModel
+
+
+class A(BaseModel):
+    abc: str = '123'
+A.abc = '456'
+A().abc = '456'
+
+class B(BaseModel):
+    abc: str = '123'
+    class Config:
+        allow_mutation=False
+B.abc = '456'
+<error descr="Property \"abc\" defined in \"B\" is read-only">B().abc = '456'</error>
+
+class C(BaseModel):
+    abc: str = '123'
+    class Config:
+        allow_mutation=True
+C.abc = '456'
+C().abc = '456'
+
+class D(BaseModel):
+    class Config:
+        allow_mutation=False
+D.abc = '456'
+<error descr="Property \"abc\" defined in \"D\" is read-only">D().abc = '456'</error>
+
+allow_mutation = True
+class E(BaseModel):
+    class Config:
+        allow_mutation=allow_mutation
+E.abc = '456'
+E().abc = '456'
+
+
+class F(D):
+    class Config:
+        allow_mutation=False
+F.abc = '456'
+<error descr="Property \"abc\" defined in \"F\" is read-only">F().abc = '456'</error>

--- a/testData/inspection/readOnlyProperty.py
+++ b/testData/inspection/readOnlyProperty.py
@@ -39,3 +39,17 @@ class F(D):
         allow_mutation=False
 F.abc = '456'
 <error descr="Property \"abc\" defined in \"F\" is read-only">F().abc = '456'</error>
+
+
+class G(BaseModel):
+    class Config:
+        allow_mutation=False
+G.abc =<EOLError descr="Expression expected"></EOLError>
+G.abc.lower()
+<error descr="Can't assign to function call">G.abc.lower()</error> = 'efg'
+
+
+class H:
+    class Config:
+        allow_mutation=False
+H.abc = '123'

--- a/testSrc/com/koxudaxi/pydantic/PydanticInspectionTest.kt
+++ b/testSrc/com/koxudaxi/pydantic/PydanticInspectionTest.kt
@@ -45,4 +45,8 @@ open class PydanticInspectionTest : PydanticInspectionBase() {
     fun testOrmMode() {
         doTest()
     }
+
+    fun testReadOnlyProperty() {
+        doTest()
+    }
 }


### PR DESCRIPTION
The PR supports to inspect the read-only property when  `allow_mutation` option is `False` on `Config`
