### PR TITLE
Fix field names treated with incorrect scope

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,9 +1,14 @@
 <idea-plugin url="https://github.com/koxudaxi/pydantic-pycharm-plugin">
     <id>com.koxudaxi.pydantic</id>
     <name>Pydantic</name>
-    <version>0.0.27</version>
+    <version>0.0.28</version>
     <vendor email="koaxudai@gmail.com">Koudai Aono @koxudaxi</vendor>
     <change-notes><![CDATA[
+    <h2>version 0.0.28</h2>
+        <p>BugFixes</p>
+    <ul>
+        <li>Fix field names treated with incorrect scope [#90] </li>
+    </ul>
     <h2>version 0.0.27</h2>
     <p>Features</p>
     <ul>

--- a/src/com/koxudaxi/pydantic/PydanticTypeProvider.kt
+++ b/src/com/koxudaxi/pydantic/PydanticTypeProvider.kt
@@ -19,7 +19,7 @@ class PydanticTypeProvider : PyTypeProviderBase() {
 
     override fun getReferenceType(referenceTarget: PsiElement, context: TypeEvalContext, anchor: PsiElement?): Ref<PyType>? {
         if (referenceTarget is PyTargetExpression) {
-            val pyClass = referenceTarget.containingClass ?: return null
+            val pyClass = referenceTarget.parent.parent.parent as? PyClass ?: return null
             if (!isPydanticModel(pyClass, context)) return null
             val name = referenceTarget.name ?: return null
             getRefTypeFromFieldName(name, context, pyClass)?.let { return it }

--- a/src/com/koxudaxi/pydantic/PydanticTypeProvider.kt
+++ b/src/com/koxudaxi/pydantic/PydanticTypeProvider.kt
@@ -19,7 +19,7 @@ class PydanticTypeProvider : PyTypeProviderBase() {
 
     override fun getReferenceType(referenceTarget: PsiElement, context: TypeEvalContext, anchor: PsiElement?): Ref<PyType>? {
         if (referenceTarget is PyTargetExpression) {
-            val pyClass = referenceTarget.parent.parent.parent as? PyClass ?: return null
+            val pyClass = referenceTarget.parent?.parent?.parent as? PyClass ?: return null
             if (!isPydanticModel(pyClass, context)) return null
             val name = referenceTarget.name ?: return null
             getRefTypeFromFieldName(name, context, pyClass)?.let { return it }


### PR DESCRIPTION
The PR fixes to reference valid local variables on a method. 

## Related Issues
https://github.com/koxudaxi/pydantic-pycharm-plugin/issues/89