### PR TITLE
fix invalid warn on no public attribute

### DIFF
--- a/src/com/koxudaxi/pydantic/PydanticInspection.kt
+++ b/src/com/koxudaxi/pydantic/PydanticInspection.kt
@@ -120,6 +120,7 @@ class PydanticInspection : PyInspection() {
             val pyClass = getPyClassByAttribute(node) ?: return
             if (!isPydanticModel(pyClass, myTypeEvalContext)) return
             if (node.annotation != null) return
+            if ((node.leftHandSideExpression as? PyTargetExpressionImpl)?.text?.startsWith("_") == true) return
             registerProblem(node,
                     "Untyped fields disallowed", ProblemHighlightType.WARNING)
 

--- a/testData/inspection/warnUntypedFields.py
+++ b/testData/inspection/warnUntypedFields.py
@@ -19,3 +19,7 @@ def e():
     ee = '123'
 
 f = '123'
+
+class G(BaseModel):
+    _g = '123'
+    __g = '123'

--- a/testData/inspection/warnUntypedFieldsDisable.py
+++ b/testData/inspection/warnUntypedFieldsDisable.py
@@ -20,3 +20,7 @@ def e():
     ee = '123'
 
 f = '123'
+
+class G(BaseModel):
+    _g = '123'
+    __g = '123'


### PR DESCRIPTION
The PR fix invalid warn on no public attribute with  `WarnUntypedFields` option

## Related Issues
https://github.com/koxudaxi/pydantic-pycharm-plugin/issues/94