### PR TITLE
Fix invalid warning when field type is any

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -8,6 +8,7 @@
     <p>BugFixes</p>
     <ul>
         <li>Fix plugin build settings [#100] </li>
+        <li>Fix an invalid warning when a field type is any [#101] </li>
     </ul>
     <h2>version 0.1.1</h2>
     <p>Features</p>

--- a/testData/mock/stub/typing/__init__.py
+++ b/testData/mock/stub/typing/__init__.py
@@ -9,6 +9,9 @@ class Optional:
     def __getitem__(cls, item):
         pass
 
+class Any:
+    pass
+
 
 class Type:
     @classmethod

--- a/testData/typecheckerinspection/field.py
+++ b/testData/typecheckerinspection/field.py
@@ -1,0 +1,17 @@
+from builtins import *
+
+from typing import *
+
+from pydantic import BaseModel
+
+
+class A(BaseModel):
+    a: int
+    b: Any
+    c: Optional[int]
+    d: Union[str, int, None]
+
+
+A(a=int(123))
+A(a=int(123), b=456, c=789, d=345)
+A(<warning descr="Expected type 'int', got 'str' instead">a=str(123)</warning>, b=456, <warning descr="Expected type 'Optional[int]', got 'str' instead">c=str(789)</warning>, <warning descr="Expected type 'Union[str, int, None]', got 'bytes' instead">d=bytes(234)</warning>)

--- a/testSrc/com/koxudaxi/pydantic/PydanticTypeCheckerInspectionTest.kt
+++ b/testSrc/com/koxudaxi/pydantic/PydanticTypeCheckerInspectionTest.kt
@@ -19,4 +19,8 @@ open class PydanticTypeCheckerInspectionTest : PydanticInspectionBase() {
         pydanticConfigService.parsableTypeMap["builtins.str"] = arrayListOf("int")
         doTest()
     }
+
+    fun testField() {
+        doTest()
+    }
 }


### PR DESCRIPTION
This PR fixes an invalid warning when a field type is any.

## ScreenShot
![Screenshot_2020-04-19_00-38-41](https://user-images.githubusercontent.com/630670/79642062-480cbc00-81d6-11ea-8625-e131b7630da9.png)
