### PR TITLE
fix type checker

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -7,8 +7,10 @@
     <h2>version 0.1.2</h2>
     <p>BugFixes</p>
     <ul>
-        <li>Fix plugin build settings [#100] </li>
+        <li>Fix type checker [#102] </li>
         <li>Fix an invalid warning when a field type is any [#101] </li>
+        <li>Fix an invalid warning when a field type is any [#101] </li>
+        <li>Fix plugin build settings [#100] </li>
     </ul>
     <h2>version 0.1.1</h2>
     <p>Features</p>

--- a/src/com/koxudaxi/pydantic/PydanticTypeCheckerInspection.kt
+++ b/src/com/koxudaxi/pydantic/PydanticTypeCheckerInspection.kt
@@ -7,7 +7,6 @@ import com.intellij.openapi.util.Key
 import com.intellij.psi.PsiElementVisitor
 import com.jetbrains.python.codeInsight.typing.matchingProtocolDefinitions
 import com.jetbrains.python.documentation.PythonDocumentationProvider
-import com.jetbrains.python.inspections.PyInspectionVisitor
 import com.jetbrains.python.inspections.PyTypeCheckerInspection
 import com.jetbrains.python.psi.*
 import com.jetbrains.python.psi.PyCallExpression.PyArgumentsMapping
@@ -24,7 +23,7 @@ class PydanticTypeCheckerInspection : PyTypeCheckerInspection() {
         return Visitor(holder, session)
     }
 
-    class Visitor(holder: ProblemsHolder?, session: LocalInspectionToolSession) : PyInspectionVisitor(holder, session) {
+    class Visitor(holder: ProblemsHolder?, session: LocalInspectionToolSession) : PyTypeCheckerInspection.Visitor(holder, session) {
         override fun visitPyCallExpression(node: PyCallExpression) {
             val pyClass = getPyClassByPyCallExpression(node, true, myTypeEvalContext)
             getPyClassByPyCallExpression(node, true, myTypeEvalContext)

--- a/testData/typecheckerinspection/class.py
+++ b/testData/typecheckerinspection/class.py
@@ -1,0 +1,8 @@
+from builtins import *
+
+class A:
+    def a(self, b: str):
+        pass
+
+A().a(<warning descr="Expected type 'str', got 'int' instead">int(123)</warning>)
+

--- a/testSrc/com/koxudaxi/pydantic/PydanticTypeCheckerInspectionTest.kt
+++ b/testSrc/com/koxudaxi/pydantic/PydanticTypeCheckerInspectionTest.kt
@@ -23,4 +23,8 @@ open class PydanticTypeCheckerInspectionTest : PydanticInspectionBase() {
     fun testField() {
         doTest()
     }
+
+    fun testClass() {
+        doTest()
+    }
 }


### PR DESCRIPTION
This PR fixes a broken type checker. 
The type checker runs for only Pydantic models. 
I'm sorry.