### PR TITLE
Fix type-map edge case for parsable-type and acceptable-type

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,9 +1,14 @@
 <idea-plugin url="https://github.com/koxudaxi/pydantic-pycharm-plugin">
     <id>com.koxudaxi.pydantic</id>
     <name>Pydantic</name>
-    <version>0.1.4</version>
+    <version>0.1.5</version>
     <vendor email="koaxudai@gmail.com">Koudai Aono @koxudaxi</vendor>
     <change-notes><![CDATA[
+    <h2>version 0.1.5</h2>
+    <p>BugFixes<p>
+    <ul>
+        <li>Fix type-map edge case for parsable-type and acceptable-type [#118]</li>
+    </ul>
     <h2>version 0.1.4</h2>
     <p>BugFixes<p>
     <ul>

--- a/src/com/koxudaxi/pydantic/PydanticInitializer.kt
+++ b/src/com/koxudaxi/pydantic/PydanticInitializer.kt
@@ -14,6 +14,7 @@ import com.intellij.openapi.vfs.newvfs.events.VFileMoveEvent
 import com.intellij.psi.util.QualifiedName
 import com.jetbrains.python.psi.PyClass
 import com.jetbrains.python.psi.PyFunction
+import com.jetbrains.python.psi.PyQualifiedNameOwner
 import com.jetbrains.python.psi.impl.PyClassImpl
 import com.jetbrains.python.psi.impl.PyFunctionImpl
 import com.jetbrains.python.psi.types.TypeEvalContext
@@ -152,9 +153,9 @@ class PydanticInitializer : StartupActivity {
         val parsableTypeTable = table.getTableOrEmpty(path).toMap()
         parsableTypeTable.entries.forEach { (key, value) ->
             val name = when (val psiElement = getPsiElementByQualifiedName(QualifiedName.fromDottedString(key), project, context)) {
-                is PyClass -> psiElement.qualifiedName!!
+                is PyQualifiedNameOwner -> psiElement.qualifiedName
                 else -> key
-            }
+            } ?: key
             run {
                 if (value is TomlArray) {
                     value.toList().filterIsInstance<String>().let {

--- a/src/com/koxudaxi/pydantic/PydanticInitializer.kt
+++ b/src/com/koxudaxi/pydantic/PydanticInitializer.kt
@@ -153,9 +153,9 @@ class PydanticInitializer : StartupActivity {
         val parsableTypeTable = table.getTableOrEmpty(path).toMap()
         parsableTypeTable.entries.forEach { (key, value) ->
             val name = when (val psiElement = getPsiElementByQualifiedName(QualifiedName.fromDottedString(key), project, context)) {
-                is PyQualifiedNameOwner -> psiElement.qualifiedName
+                is PyQualifiedNameOwner -> psiElement.qualifiedName!!
                 else -> key
-            } ?: key
+            }
             run {
                 if (value is TomlArray) {
                     value.toList().filterIsInstance<String>().let {

--- a/testData/initializer/pyprojecttoml/pyproject.toml
+++ b/testData/initializer/pyprojecttoml/pyproject.toml
@@ -6,7 +6,7 @@ acceptable-type-highlight = "warning"
 [tool.pydantic-pycharm-plugin.parsable-types]
 ## datetime.datetime field may parse int
 "datetime.datetime" = ["int"]
-
+"pydantic.HttpUrl" = ["str"]
 [tool.pydantic-pycharm-plugin.acceptable-types]
 # str field accepts to parse int and float
 str = ["int", "float"]

--- a/testData/mock/pydanticv1/__init__.py
+++ b/testData/mock/pydanticv1/__init__.py
@@ -2,3 +2,4 @@ from .main import BaseModel, BaseConfig
 from .class_validators import validator, root_validator
 from .fields import Field, Schema
 from .env_settings import BaseSettings
+from .networks import *

--- a/testData/mock/pydanticv1/networks.py
+++ b/testData/mock/pydanticv1/networks.py
@@ -1,0 +1,6 @@
+from builtins import str
+
+class AnyUrl(str):
+    pass
+class HttpUrl(AnyUrl):
+    pass

--- a/testSrc/com/koxudaxi/pydantic/PydanticInitializerTest.kt
+++ b/testSrc/com/koxudaxi/pydantic/PydanticInitializerTest.kt
@@ -38,7 +38,10 @@ open class PydanticInitializerTest : PydanticTestCase() {
 
     fun testpyprojecttoml() {
         setUpPyProjectToml {
-            assertEquals(this.pydanticConfigService.parsableTypeMap, mutableMapOf("datetime.datetime" to listOf("int")))
+            assertEquals(this.pydanticConfigService.parsableTypeMap, mutableMapOf(
+                    "datetime.datetime" to listOf("int"),
+                    "pydantic.networks.HttpUrl" to listOf("str")
+            ))
             assertEquals(this.pydanticConfigService.acceptableTypeMap, mutableMapOf("str" to listOf("int", "float")))
             assertEquals(this.pydanticConfigService.parsableTypeHighlightType, ProblemHighlightType.WEAK_WARNING)
             assertEquals(this.pydanticConfigService.acceptableTypeHighlightType, ProblemHighlightType.WARNING)


### PR DESCRIPTION
This PR fixes the type-map edge case.

we expect  `HttpUrl` is `pydantic.HttpUrl`.
```toml
"pydantic.HttpUrl" = ["str"]
```
But, actual path is `pydantic.networks.HttpUrl`.
This PR fixes this case.

## Related issues
https://github.com/koxudaxi/pydantic-pycharm-plugin/issues/99