### PR TITLE
add sdk mock for python

### DIFF
--- a/LICENSE_apache_version_2.txt
+++ b/LICENSE_apache_version_2.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2000-2018 JetBrains s.r.o.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ allprojects {
         compile "org.apache.tuweni:tuweni-toml:0.10.0"
         compile group: 'org.ini4j', name: 'ini4j', version: '0.5.4'
         testCompile group: 'junit', name: 'junit', version: '4.11'
+        compile group: 'org.jetbrains', name: 'annotations', version: '19.0.0'
     }
 
     jacocoTestReport {

--- a/docs/development.md
+++ b/docs/development.md
@@ -20,3 +20,9 @@ $ gradlew.bat buildPlugin
 ```bash
 $ ./gradlew runIde
 ```
+
+
+## License For testSrc/com/jetbrains
+These files are copied to `testSrc/com/jetbrains` from [IntelliJ IDEA Community Edition](https://github.com/JetBrains/intellij-community)
+The files are licensed under the Apache License, Version 2.0.
+http://www.apache.org/licenses/LICENSE-2.0

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -7,6 +7,7 @@
     <h2>version 0.1.6</h2>
     <p>Features</p>
     <ul>
+        <li>Add mock sdk for unittest [#124] </li>
         <li>Fix types of methods and functions [#123] </li>
     </ul>
     <h2>version 0.1.5</h2>

--- a/testData/completion/classInitMethod.py
+++ b/testData/completion/classInitMethod.py
@@ -1,0 +1,13 @@
+from builtins import *
+
+from pydantic import BaseModel
+
+class A(BaseModel):
+    abc: str
+
+class B(A):
+    efg: str
+    def __init__(self):
+        return self.<caret>
+
+

--- a/testSrc/com/jetbrains/python/PythonMockSdk.java
+++ b/testSrc/com/jetbrains/python/PythonMockSdk.java
@@ -1,0 +1,103 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.jetbrains.python;
+
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.projectRoots.SdkAdditionalData;
+import com.intellij.openapi.projectRoots.SdkTypeId;
+import com.intellij.openapi.projectRoots.impl.MockSdk;
+import com.intellij.openapi.roots.OrderRootType;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.containers.ContainerUtil;
+import com.intellij.util.containers.MultiMap;
+import com.jetbrains.python.codeInsight.typing.PyTypeShed;
+import com.jetbrains.python.codeInsight.userSkeletons.PyUserSkeletonsUtil;
+import com.jetbrains.python.psi.LanguageLevel;
+import com.jetbrains.python.sdk.PythonSdkUtil;
+import org.jdom.Element;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Comparator;
+
+/**
+ * @author yole
+ */
+public class PythonMockSdk {
+    @NonNls private static final String MOCK_SDK_NAME = "Mock Python SDK";
+
+    private PythonMockSdk() {
+    }
+
+    public static Sdk create(final String version, final VirtualFile @NotNull ... additionalRoots) {
+        final String mock_path = PythonTestUtil.getTestDataPath() + "/MockSdk" + version + "/";
+
+        String sdkHome = new File(mock_path, "bin/python" + version).getPath();
+
+        MultiMap<OrderRootType, VirtualFile> roots = MultiMap.create();
+        OrderRootType classes = OrderRootType.CLASSES;
+
+        ContainerUtil.putIfNotNull(classes, LocalFileSystem.getInstance().refreshAndFindFileByIoFile(new File(mock_path, "Lib")), roots);
+
+        ContainerUtil.putIfNotNull(classes, PyUserSkeletonsUtil.getUserSkeletonsDirectory(), roots);
+
+        final LanguageLevel level = LanguageLevel.fromPythonVersion(version);
+        final VirtualFile typeShedDir = PyTypeShed.INSTANCE.getDirectory();
+        PyTypeShed.INSTANCE
+                .findRootsForLanguageLevel(level)
+                .forEach(path -> ContainerUtil.putIfNotNull(classes, typeShedDir.findFileByRelativePath(path), roots));
+
+        String mock_stubs_path = mock_path + PythonSdkUtil.SKELETON_DIR_NAME;
+        ContainerUtil.putIfNotNull(classes, LocalFileSystem.getInstance().refreshAndFindFileByPath(mock_stubs_path), roots);
+
+        roots.putValues(classes, Arrays.asList(additionalRoots));
+
+        MockSdk sdk = new MockSdk(MOCK_SDK_NAME + " " + version, sdkHome, "Python " + version + " Mock SDK", roots, new PyMockSdkType(version));
+
+        // com.jetbrains.python.psi.resolve.PythonSdkPathCache.getInstance() corrupts SDK, so have to clone
+        return sdk.clone();
+    }
+
+    private static class PyMockSdkType implements SdkTypeId {
+
+        @NotNull
+        private final String myVersionString;
+        private final String mySdkIdName;
+
+        private PyMockSdkType(@NotNull String string) {
+            mySdkIdName = PyNames.PYTHON_SDK_ID_NAME;
+            myVersionString = string;
+        }
+
+        @NotNull
+        @Override
+        public String getName() {
+            return mySdkIdName;
+        }
+
+        @Nullable
+        @Override
+        public String getVersionString(@NotNull Sdk sdk) {
+            return myVersionString;
+        }
+
+        @Override
+        public void saveAdditionalData(@NotNull SdkAdditionalData additionalData, @NotNull Element additional) {
+
+        }
+
+        @Nullable
+        @Override
+        public SdkAdditionalData loadAdditionalData(@NotNull Sdk currentSdk, @NotNull Element additional) {
+            return null;
+        }
+
+        @Override
+        public boolean isLocalSdk(@NotNull Sdk sdk) {
+            return false;
+        }
+    }
+}

--- a/testSrc/com/jetbrains/python/PythonTestUtil.java
+++ b/testSrc/com/jetbrains/python/PythonTestUtil.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2000-2013 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jetbrains.python;
+
+/**
+ * @author yole
+ */
+public class PythonTestUtil {
+    private PythonTestUtil() {
+    }
+
+    public static String getTestDataPath() {
+        return PythonHelpersLocator.getPythonCommunityPath() + "/testData";
+    }
+}

--- a/testSrc/com/jetbrains/python/fixtures/PyLightProjectDescriptor.java
+++ b/testSrc/com/jetbrains/python/fixtures/PyLightProjectDescriptor.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2000-2015 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jetbrains.python.fixtures;
+
+import com.intellij.openapi.application.PathManager;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.roots.ModifiableRootModel;
+import com.intellij.openapi.roots.OrderRootType;
+import com.intellij.openapi.roots.libraries.Library;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.testFramework.LightProjectDescriptor;
+import com.jetbrains.python.PythonMockSdk;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Project descriptor (extracted from {@link com.jetbrains.python.fixtures.PyTestCase}) and should be used with it.
+ * @author Ilya.Kazakevich
+ */
+public class PyLightProjectDescriptor extends LightProjectDescriptor {
+    private final String myPythonVersion;
+
+    public PyLightProjectDescriptor(String pythonVersion) {
+        myPythonVersion = pythonVersion;
+    }
+
+    @NotNull
+    @Override
+    public String getModuleTypeId() {
+        return "EMPTY_MODULE";
+    }
+
+    @Override
+    public Sdk getSdk() {
+        return PythonMockSdk.create(myPythonVersion, getAdditionalRoots());
+    }
+
+    /**
+     * @return additional roots to add to mock python
+     */
+    protected VirtualFile [] getAdditionalRoots() {
+        return VirtualFile.EMPTY_ARRAY;
+    }
+
+    protected void createLibrary(ModifiableRootModel model, final String name, final String path) {
+        final Library.ModifiableModel modifiableModel = model.getModuleLibraryTable().createLibrary(name).getModifiableModel();
+        final VirtualFile home =
+                LocalFileSystem.getInstance().refreshAndFindFileByPath(PathManager.getHomePath() + path);
+
+        modifiableModel.addRoot(home, OrderRootType.CLASSES);
+        modifiableModel.commit();
+    }
+}

--- a/testSrc/com/koxudaxi/pydantic/PydanticCompletionTest.kt
+++ b/testSrc/com/koxudaxi/pydantic/PydanticCompletionTest.kt
@@ -527,6 +527,16 @@ open class PydanticCompletionTest : PydanticTestCase() {
         )
     }
 
+    fun testClassInitMethod() {
+        doFieldTest(
+                listOf(
+                        Pair("abc", "str A"),
+                        Pair("efg", "str B"),
+                        Pair("___slots__", "BaseModel")
+                )
+        )
+    }
+
     fun testMethodSelf() {
         doFieldTest(
                 listOf(

--- a/testSrc/com/koxudaxi/pydantic/PydanticCompletionTest.kt
+++ b/testSrc/com/koxudaxi/pydantic/PydanticCompletionTest.kt
@@ -9,11 +9,15 @@ open class PydanticCompletionTest : PydanticTestCase() {
 
     private fun doFieldTest(fieldNames: List<Pair<String, String>>, additionalModules: List<String>? = null) {
         configureByFile(additionalModules)
-
+        val excludes = listOf(
+                "__annotations__", "__base__", "__bases__", "__basicsize__", "__dict__", "__dictoffset__", "__flags__",
+                "__itemsize__", "__mro__", "__name__", "__qualname__", "__slots__", "__text_signature__",
+                "__weakrefoffset__", "Ellipsis", "EnvironmentError", "IOError", "NotImplemented")
         val actual = myFixture!!.completeBasic().filter {
             it!!.psiElement is PyTargetExpression
+        }.filterNot {
+            excludes.contains(it!!.lookupString)
         }.mapNotNull {
-
             Pair(it!!.lookupString, LookupElementPresentation.renderElement(it).typeText ?: "null")
         }
         assertEquals(fieldNames, actual)

--- a/testSrc/com/koxudaxi/pydantic/PydanticCompletionV0Test.kt
+++ b/testSrc/com/koxudaxi/pydantic/PydanticCompletionV0Test.kt
@@ -33,7 +33,10 @@ open class PydanticCompletionV0Test : PydanticTestCase(version = "v0") {
                         Pair("f_id", "str A"),
                         Pair("g_id", "str=get_alias() A"),
                         Pair("hij", "Any A"),
-                        Pair("___slots__", "BaseModel")
+                        Pair("___slots__", "BaseModel"),
+                        Pair("__annotations__", "object"),
+                        Pair("__dict__", "object"),
+                        Pair("__slots__", "object")
                 )
         )
     }
@@ -53,6 +56,10 @@ open class PydanticCompletionV0Test : PydanticTestCase(version = "v0") {
                         Pair("f_id=", "str A"),
                         Pair("g_id=", "str=get_alias() A"),
                         Pair("hij=", "Any A"),
+                        Pair("Ellipsis", "builtins"),
+                        Pair("EnvironmentError", "builtins"),
+                        Pair("IOError", "builtins"),
+                        Pair("NotImplemented", "builtins"),
                         Pair("b_id", "null")
                 )
         )

--- a/testSrc/com/koxudaxi/pydantic/PydanticTestCase.kt
+++ b/testSrc/com/koxudaxi/pydantic/PydanticTestCase.kt
@@ -10,14 +10,16 @@ import com.intellij.testFramework.fixtures.CodeInsightTestFixture
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
 import com.intellij.testFramework.fixtures.impl.LightTempDirTestFixtureImpl
 import com.jetbrains.python.PythonDialectsTokenSetProvider
+import com.jetbrains.python.fixtures.PyLightProjectDescriptor
 import com.jetbrains.python.psi.LanguageLevel
 import com.jetbrains.python.psi.impl.PythonLanguageLevelPusher
 
 abstract class PydanticTestCase(version: String = "v1") : UsefulTestCase() {
 
     protected var myFixture: CodeInsightTestFixture? = null
+    private val PYTHON_3_MOCK_SDK = "3.7"
 
-    private val projectDescriptor: LightProjectDescriptor? = LightProjectDescriptor()
+    private val projectDescriptor: PyLightProjectDescriptor? = PyLightProjectDescriptor(PYTHON_3_MOCK_SDK)
     private val testDataPath: String = "testData"
     private val mockPath: String = "mock"
     private val pydanticMockPath: String = "$mockPath/pydantic$version"

--- a/testSrc/com/koxudaxi/pydantic/PydanticTestCase.kt
+++ b/testSrc/com/koxudaxi/pydantic/PydanticTestCase.kt
@@ -19,7 +19,7 @@ abstract class PydanticTestCase(version: String = "v1") : UsefulTestCase() {
     protected var myFixture: CodeInsightTestFixture? = null
     private val PYTHON_3_MOCK_SDK = "3.7"
 
-    private val projectDescriptor: PyLightProjectDescriptor? = PyLightProjectDescriptor(PYTHON_3_MOCK_SDK)
+    private val projectDescriptor: PyLightProjectDescriptor = PyLightProjectDescriptor(PYTHON_3_MOCK_SDK)
     private val testDataPath: String = "testData"
     private val mockPath: String = "mock"
     private val pydanticMockPath: String = "$mockPath/pydantic$version"


### PR DESCRIPTION
This PR adds an sdk for the unittest.
The class is copied to `testSrc/com/jetbrains` from [IntelliJ IDEA Community Edition](https://github.com/JetBrains/intellij-community)