### PR TITLE
PyCharm 2021.2.1 API changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 mkdocs==1.2.2
-mkdocs-material==7.2.0
+mkdocs-material==7.2.1

--- a/src/com/koxudaxi/pydantic/PydanticTypeCheckerInspection.kt
+++ b/src/com/koxudaxi/pydantic/PydanticTypeCheckerInspection.kt
@@ -108,7 +108,7 @@ class PydanticTypeCheckerInspection : PyTypeCheckerInspection() {
             for ((argument, parameter) in PyCallExpressionHelper.getRegularMappedParameters(mappedParameters)) {
                 val expected = parameter.getArgumentType(myTypeEvalContext)
                 val actual = promoteToLiteral(argument, expected, myTypeEvalContext)
-                val strictMatched = matchParameterAndArgument(expected, actual, argument, substitutions)
+                val strictMatched = matchParameterAndArgument(expected, actual, substitutions)
                 val strictResult = AnalyzeArgumentResult(expected, actual, strictMatched)
                 if (!strictResult.isMatched) {
                     val expectedType =
@@ -118,7 +118,7 @@ class PydanticTypeCheckerInspection : PyTypeCheckerInspection() {
                         val parsableType = getParsableTypeFromTypeMap(expected, cachedParsableTypeMap)
                         if (parsableType != null) {
                             val parsableMatched =
-                                matchParameterAndArgument(parsableType, actual, argument, substitutions)
+                                matchParameterAndArgument(parsableType, actual, substitutions)
                             if (AnalyzeArgumentResult(parsableType, actual, parsableMatched).isMatched) {
                                 registerProblem(
                                     argument,
@@ -134,7 +134,7 @@ class PydanticTypeCheckerInspection : PyTypeCheckerInspection() {
                         val acceptableType = getAcceptableTypeFromTypeMap(expected, cachedAcceptableTypeMap)
                         if (acceptableType != null) {
                             val acceptableMatched =
-                                matchParameterAndArgument(acceptableType, actual, argument, substitutions)
+                                matchParameterAndArgument(acceptableType, actual, substitutions)
                             if (AnalyzeArgumentResult(acceptableType, actual, acceptableMatched).isMatched) {
                                 registerProblem(
                                     argument,
@@ -159,12 +159,9 @@ class PydanticTypeCheckerInspection : PyTypeCheckerInspection() {
         private fun matchParameterAndArgument(
             parameterType: PyType?,
             argumentType: PyType?,
-            argument: PyExpression?,
             substitutions: Map<PyGenericType, PyType>,
         ): Boolean {
-            return if (parameterType is PyTypedDictType && argument is PyDictLiteralExpression) match((parameterType as PyTypedDictType?)!!,
-                (argument as PyDictLiteralExpression?)!!,
-                myTypeEvalContext) else PyTypeChecker.match(parameterType,
+            return PyTypeChecker.match(parameterType,
                 argumentType,
                 myTypeEvalContext,
                 substitutions) &&


### PR DESCRIPTION
Hello. In PyCharm 2021.2.1 there will be a breaking change in API: `com.jetbrains.python.psi.types.PyTypedDictType.Companion.match(PyTypedDictType, PyDictLiteralExpression, TypeEvalContext)` method will be removed.
The type inference for collections was refactored to fix https://youtrack.jetbrains.com/issue/PY-48799, and starting from 2021.2.1 for dict literals containing only string keys we will infer PyTypedDictType, so there'll be no need to match dict literals with TypedDicts. There's a new method for comparing the inferred TypedDicts with the type hints: `com.jetbrains.python.psi.types.PyTypedDictType.Companion.match(PyType, PyTypedDictType, TypeEvalContext)`.
PyCharm 2021.2.1 will be released near the end of August.
