### PR TITLE
Fix issue where changelog PRs were failing to generate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,5 +83,5 @@ jobs:
           gh pr create \
             --title "Changelog update - \`$VERSION\`" \
             --body "Current pull request contains patched \`CHANGELOG.md\` file for the \`$VERSION\` version." \
-            --base main \
+            --base master \
             --head $BRANCH


### PR DESCRIPTION
The IntelliJ template assumes that the default branch will be "main", this repository uses "master".

https://github.com/koxudaxi/pydantic-pycharm-plugin/pull/436#issuecomment-1047932399
https://github.com/koxudaxi/pydantic-pycharm-plugin/runs/5290676713?check_suite_focus=true