### PR TITLE
Fix wrong renaming of a local variable name is same as field name

### DIFF
--- a/src/com/koxudaxi/pydantic/PydanticFieldRenameFactory.kt
+++ b/src/com/koxudaxi/pydantic/PydanticFieldRenameFactory.kt
@@ -19,9 +19,11 @@ class PydanticFieldRenameFactory : AutomaticRenamerFactory {
     override fun isApplicable(element: PsiElement): Boolean {
         when (element) {
             is PyTargetExpression -> {
+                val elementName = element.name ?: return false
                 val pyClass = element.containingClass ?: return false
-                val content = TypeEvalContext.codeAnalysis(element.project, element.containingFile)
-                if (isPydanticModel(pyClass, true, content)) return true
+                val context = TypeEvalContext.codeAnalysis(element.project, element.containingFile)
+                if (pyClass.findClassAttribute(elementName, true, context) != element) return false
+                if (isPydanticModel(pyClass, true, context)) return true
             }
             is PyKeywordArgument -> {
                 val context = TypeEvalContext.codeAnalysis(element.project, element.containingFile)
@@ -56,8 +58,10 @@ class PydanticFieldRenameFactory : AutomaticRenamerFactory {
                     element.name?.let { name ->
                         element.containingClass
                             ?.let { pyClass ->
-                                val content = TypeEvalContext.codeAnalysis(element.project, element.containingFile)
-                                addAllElement(pyClass, name, added, content)
+                                val context = TypeEvalContext.codeAnalysis(element.project, element.containingFile)
+                                 if (pyClass.findClassAttribute(name, true, context) == element ) {
+                                     addAllElement(pyClass, name, added, context)
+                                 }
                             }
                         suggestAllNames(name, newName)
                     }

--- a/src/com/koxudaxi/pydantic/PydanticFieldSearchExecutor.kt
+++ b/src/com/koxudaxi/pydantic/PydanticFieldSearchExecutor.kt
@@ -31,6 +31,7 @@ class PydanticFieldSearchExecutor : QueryExecutorBase<PsiReference, ReferencesSe
                     ?.let { elementName ->
                         val context = TypeEvalContext.userInitiated(element.project, element.containingFile)
                         element.containingClass
+                            ?.takeIf { it.findClassAttribute(elementName, true, context) == element }
                             ?.takeIf { pyClass -> isPydanticModel(pyClass, true, context) }
                             ?.let { pyClass ->
                                 searchAllElementReference(pyClass,

--- a/testData/refactor/renameMethodLocalVariable.py
+++ b/testData/refactor/renameMethodLocalVariable.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+
+class A(BaseModel):
+    abc = ""
+
+    @classmethod
+    def do(cls):
+        a<caret>bc = "abc"
+        assert abc

--- a/testData/refactor/renameMethodLocalVariable_after.py
+++ b/testData/refactor/renameMethodLocalVariable_after.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+
+class A(BaseModel):
+    abc = ""
+
+    @classmethod
+    def do(cls):
+        cde = "abc"
+        assert cde

--- a/testData/search/methodLocalVariable.py
+++ b/testData/search/methodLocalVariable.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+
+
+class A(BaseModel):
+    abc = ""
+
+    @classmethod
+    def do(cls):
+        a<caret>bc = "abc"
+        assert abc # expected
+        ## count: 2

--- a/testSrc/com/koxudaxi/pydantic/PydanticRefactorTest.kt
+++ b/testSrc/com/koxudaxi/pydantic/PydanticRefactorTest.kt
@@ -75,6 +75,10 @@ open class PydanticRefactorTest : PydanticTestCase() {
 
     }
 
+    fun testRenameMethodLocalVariable() {
+        doRefactorTest(isApplicable = false)
+    }
+
     fun testGetOptionName() {
         assertEquals(PydanticFieldRenameFactory().optionName, "Rename fields in hierarchy")
     }

--- a/testSrc/com/koxudaxi/pydantic/PydanticSearchTest.kt
+++ b/testSrc/com/koxudaxi/pydantic/PydanticSearchTest.kt
@@ -106,4 +106,8 @@ open class PydanticSearchTest : PydanticTestCase() {
     fun testParameter() {
         assertMatch(2)
     }
+
+    fun testMethodLocalVariable() {
+        assertMatch(2)
+    }
 }


### PR DESCRIPTION
Closes:  https://github.com/koxudaxi/pydantic-pycharm-plugin/issues/484