### PR TITLE
Ignore `__init__` method if parameter is only only `**kwargs` arguments.

### DIFF
--- a/docs/ignore-init-arguments.md
+++ b/docs/ignore-init-arguments.md
@@ -21,5 +21,21 @@ The option has to be defined in pyproject.toml
 ```toml
 [tool.pydantic-pycharm-plugin]
 ignore-init-method-arguments = true
+```
 
+!!! info    
+**This feature is in version 0.4.9 or later**
+
+If a third-party library provides a model that extends BaseModel, it may override the `__init__` method, as in `__init__(self, **kwargs)`.
+If this is the case, the plugin user should set `ignore-init-method-arguments = true` to ignore the `__init__` method argument.
+But it is difficult to tell if the library is using BaseModel or not.
+
+The plugin ignore the `__init__` method if argument is only `**kwargs`. the option is provided as `ignore-init-method-keyword-arguments`.
+This option is enabled by default, so if you create a model that inherits from BaseModel with a method like `__init__(self, **kwargs)` defined, ignore this `init` argument.
+
+If you want to disable this option, please put the following setting in `pyproject.toml`.
+
+```toml
+[tool.pydantic-pycharm-plugin].
+ignore-init-method-keyword-arguments = true
 ```

--- a/docs/ignore-init-keyword-arguments.md
+++ b/docs/ignore-init-keyword-arguments.md
@@ -1,0 +1,26 @@
+# Ignore `__init__` method arguments 
+
+
+!!! info    
+    **This feature is in version 0.4.8 or later**
+
+You can write `__init__` method on a model for adding some logic.
+
+However, default arguments on `__init__` method will be overridden, And you will lose autocompletion for `__init__` methods by the plugin.  
+
+![options_init](init_arguments.png)
+ 
+`ignore-init-method-arguments` option resolves this problem.
+The option ignore arguments on `__init__` method.
+
+![options_ignore_init](ignore_init_arguments.png)
+
+
+The option has to be defined in pyproject.toml
+
+```toml
+[tool.pydantic-pycharm-plugin]
+ignore-init-method-keyword-arguments = false
+
+```
+

--- a/src/com/koxudaxi/pydantic/PydanticConfigService.kt
+++ b/src/com/koxudaxi/pydantic/PydanticConfigService.kt
@@ -20,6 +20,7 @@ class PydanticConfigService : PersistentStateComponent<PydanticConfigService> {
     var acceptableTypeMap = mapOf<String, List<String>>()
     var acceptableTypeHighlightType: ProblemHighlightType = ProblemHighlightType.WEAK_WARNING
     var ignoreInitMethodArguments: Boolean = false
+    var ignoreInitMethodKeywordArguments: Boolean = true
     val currentInitTyped: Boolean
         get() = this.mypyInitTyped ?: this.initTyped
     val currentWarnUntypedFields: Boolean

--- a/src/com/koxudaxi/pydantic/PydanticInitializer.kt
+++ b/src/com/koxudaxi/pydantic/PydanticInitializer.kt
@@ -142,6 +142,8 @@ class PydanticInitializer : ProjectActivity {
             getHighlightLevel(table, "acceptable-type-highlight", ProblemHighlightType.WEAK_WARNING)
 
         configService.ignoreInitMethodArguments = table.getBoolean("ignore-init-method-arguments") ?: false
+        configService.ignoreInitMethodKeywordArguments =
+            table.getBoolean("ignore-init-method-keyword-arguments") ?: true
     }
 
     private fun getHighlightLevel(table: TomlTable, path: String, default: ProblemHighlightType): ProblemHighlightType {

--- a/src/com/koxudaxi/pydantic/PydanticTypeProvider.kt
+++ b/src/com/koxudaxi/pydantic/PydanticTypeProvider.kt
@@ -479,18 +479,6 @@ class PydanticTypeProvider : PyTypeProviderBase() {
         getPydanticModelInit(pyClass, context)?.let {
             val callParameters = it.getParameters(context)
                 .filterNot { parameter -> parameter.isSelf }
-            val callParametersWithoutKeywordContainer = callParameters.filterNot {
-                parameter -> parameter.isKeywordContainer
-            }
-            val hasKeywordContainer = callParametersWithoutKeywordContainer.size != callParameters.size
-            if (hasKeywordContainer) {
-                val hasNonPositionalContainer = callParametersWithoutKeywordContainer.any {
-                    parameter -> !parameter.isPositionalContainer
-                }
-                if (!hasNonPositionalContainer) {
-                    return@let null
-                }
-            }
             return PyCallableTypeImpl(callParameters, clsType.toInstance())
         }
 

--- a/src/com/koxudaxi/pydantic/PydanticTypeProvider.kt
+++ b/src/com/koxudaxi/pydantic/PydanticTypeProvider.kt
@@ -479,6 +479,18 @@ class PydanticTypeProvider : PyTypeProviderBase() {
         getPydanticModelInit(pyClass, context)?.let {
             val callParameters = it.getParameters(context)
                 .filterNot { parameter -> parameter.isSelf }
+            val callParametersWithoutKeywordContainer = callParameters.filterNot {
+                parameter -> parameter.isKeywordContainer
+            }
+            val hasKeywordContainer = callParametersWithoutKeywordContainer.size != callParameters.size
+            if (hasKeywordContainer) {
+                val hasNonPositionalContainer = callParametersWithoutKeywordContainer.any {
+                    parameter -> !parameter.isPositionalContainer
+                }
+                if (!hasNonPositionalContainer) {
+                    return@let null
+                }
+            }
             return PyCallableTypeImpl(callParameters, clsType.toInstance())
         }
 

--- a/testData/completion/keywordArgumentInitArgsKwargs.py
+++ b/testData/completion/keywordArgumentInitArgsKwargs.py
@@ -1,0 +1,16 @@
+
+
+from pydantic import BaseModel
+
+class Z(BaseModel):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+class A(Z):
+    abc: str
+    cde: str
+    efg: str
+
+class B(A):
+    hij: str
+
+A(<caret>)

--- a/testData/completion/keywordArgumentInitArgsKwargsDisable.py
+++ b/testData/completion/keywordArgumentInitArgsKwargsDisable.py
@@ -1,0 +1,16 @@
+
+
+from pydantic import BaseModel
+
+class Z(BaseModel):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+class A(Z):
+    abc: str
+    cde: str
+    efg: str
+
+class B(A):
+    hij: str
+
+A(<caret>)

--- a/testData/completion/keywordArgumentInitKwargs.py
+++ b/testData/completion/keywordArgumentInitKwargs.py
@@ -1,0 +1,16 @@
+
+
+from pydantic import BaseModel
+
+class Z(BaseModel):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+class A(Z):
+    abc: str
+    cde: str
+    efg: str
+
+class B(A):
+    hij: str
+
+A(<caret>)

--- a/testData/completion/keywordArgumentInitPosition.py
+++ b/testData/completion/keywordArgumentInitPosition.py
@@ -1,0 +1,16 @@
+
+
+from pydantic import BaseModel
+
+class Z(BaseModel):
+    def __init__(self, xyz: str):
+        super().__init__()
+class A(Z):
+    abc: str
+    cde: str
+    efg: str
+
+class B(A):
+    hij: str
+
+A(<caret>)

--- a/testData/initializer/pyprojecttoml/pyproject.toml
+++ b/testData/initializer/pyprojecttoml/pyproject.toml
@@ -4,6 +4,8 @@ parsable-type-highlight = "weak_warning"
 acceptable-type-highlight = "warning"
 
 ignore-init-method-arguments = true
+ignore-init-method-keyword-arguments = false
+
 
 [tool.pydantic-pycharm-plugin.parsable-types]
 ## datetime.datetime field may parse int

--- a/testSrc/com/koxudaxi/pydantic/PydanticCompletionTest.kt
+++ b/testSrc/com/koxudaxi/pydantic/PydanticCompletionTest.kt
@@ -712,6 +712,34 @@ open class PydanticCompletionTest : PydanticTestCase() {
         )
     }
 
+    fun testKeywordArgumentInitArgsKwargs() {
+        doFieldTest(
+                listOf(
+                        Pair("abc=", "str A"),
+                        Pair("cde=", "str A"),
+                        Pair("efg=", "str A")
+                )
+        )
+    }
+
+    fun testKeywordArgumentInitKwargs() {
+        doFieldTest(
+                listOf(
+                        Pair("abc=", "str A"),
+                        Pair("cde=", "str A"),
+                        Pair("efg=", "str A")
+                )
+        )
+    }
+
+    fun testKeywordArgumentInitPosition() {
+        doFieldTest(
+                listOf(
+                        Pair("xyz=", "str A")
+                )
+        )
+    }
+
     fun testdataclassKeywordArgument() {
         doFieldTest(
             listOf(

--- a/testSrc/com/koxudaxi/pydantic/PydanticCompletionTest.kt
+++ b/testSrc/com/koxudaxi/pydantic/PydanticCompletionTest.kt
@@ -721,7 +721,18 @@ open class PydanticCompletionTest : PydanticTestCase() {
                 )
         )
     }
-
+    fun testKeywordArgumentInitArgsKwargsDisable() {
+        val config = PydanticConfigService.getInstance(myFixture!!.project)
+        config.ignoreInitMethodKeywordArguments = false
+        try {
+            doFieldTest(
+                emptyList(
+                )
+        )}
+        finally {
+            config.ignoreInitMethodKeywordArguments = true
+        }
+    }
     fun testKeywordArgumentInitKwargs() {
         doFieldTest(
                 listOf(
@@ -734,9 +745,7 @@ open class PydanticCompletionTest : PydanticTestCase() {
 
     fun testKeywordArgumentInitPosition() {
         doFieldTest(
-                listOf(
-                        Pair("xyz=", "str A")
-                )
+            emptyList()
         )
     }
 

--- a/testSrc/com/koxudaxi/pydantic/PydanticInitializerTest.kt
+++ b/testSrc/com/koxudaxi/pydantic/PydanticInitializerTest.kt
@@ -60,6 +60,7 @@ open class PydanticInitializerTest : PydanticTestCase() {
                 assertEquals(this.pydanticConfigService.parsableTypeHighlightType, ProblemHighlightType.WEAK_WARNING)
                 assertEquals(this.pydanticConfigService.acceptableTypeHighlightType, ProblemHighlightType.WARNING)
                 assertEquals(this.pydanticConfigService.ignoreInitMethodArguments, true)
+                assertEquals(this.pydanticConfigService.ignoreInitMethodKeywordArguments, false)
             }
         }
     }
@@ -96,6 +97,7 @@ open class PydanticInitializerTest : PydanticTestCase() {
                 assertEquals(this.pydanticConfigService.parsableTypeHighlightType, ProblemHighlightType.WARNING)
                 assertEquals(this.pydanticConfigService.acceptableTypeHighlightType, ProblemHighlightType.WEAK_WARNING)
                 assertEquals(this.pydanticConfigService.ignoreInitMethodArguments, false)
+                assertEquals(this.pydanticConfigService.ignoreInitMethodKeywordArguments, true)
            }
         }
     }


### PR DESCRIPTION
Closes: https://github.com/koxudaxi/pydantic-pycharm-plugin/issues/471 https://github.com/koxudaxi/pydantic-pycharm-plugin/issues/796

Often, Third party libraries override BaseModel's `__init__` with `**kwargs`. So, the PyCharm will no longer perform completion and type checking.
Setting `ignore-init-method-arguments = true` causes init method to be ignored, but for convenience, add a new `ignore-init-method-keyword-arguments ` and enable it by default