### PR TITLE
Fix: Allow user-defined fields with `model_` prefix in Pydantic v2

### DIFF
--- a/src/com/koxudaxi/pydantic/Pydantic.kt
+++ b/src/com/koxudaxi/pydantic/Pydantic.kt
@@ -195,9 +195,27 @@ val CONFIG_TYPES = mapOf(
 
 const val CUSTOM_ROOT_FIELD = "__root__"
 
-const val MODEL_FIELD_PREFIX = "model_"
-
 const val MODEL_CONFIG_FIELD = "model_config"
+
+// Pydantic v2 BaseModel reserved attribute names
+val PYDANTIC_V2_MODEL_RESERVED_ATTRIBUTES = setOf(
+    "model_config",
+    "model_fields",
+    "model_computed_fields",
+    "model_extra",
+    "model_fields_set",
+    "model_construct",
+    "model_copy",
+    "model_dump",
+    "model_dump_json",
+    "model_json_schema",
+    "model_parametrized_name",
+    "model_post_init",
+    "model_rebuild",
+    "model_validate",
+    "model_validate_json",
+    "model_validate_strings",
+)
 
 fun PyTypedElement.getType(context: TypeEvalContext): PyType? = context.getType(this)
 
@@ -437,7 +455,7 @@ fun isValidField(field: PyTargetExpression, context: TypeEvalContext, isV2: Bool
     return !(PyTypingTypeProvider.isClassVar(field, context) || PyTypingTypeProvider.isFinal(field, context))
 }
 
-fun String.isValidFieldName(isV2: Boolean): Boolean = (!startsWith('_') || this == CUSTOM_ROOT_FIELD) && !(isV2 && this.startsWith(MODEL_FIELD_PREFIX))
+fun String.isValidFieldName(isV2: Boolean): Boolean = (!startsWith('_') || this == CUSTOM_ROOT_FIELD) && !(isV2 && this in PYDANTIC_V2_MODEL_RESERVED_ATTRIBUTES)
 
 fun getConfigValue(name: String, value: Any?, context: TypeEvalContext): Any? {
     if (value is PyReferenceExpression) {

--- a/src/com/koxudaxi/pydantic/PydanticInspection.kt
+++ b/src/com/koxudaxi/pydantic/PydanticInspection.kt
@@ -441,7 +441,7 @@ class PydanticInspection : PyInspection() {
             val pydanticVersion = PydanticCacheService.getVersion(pyClass.project)
 
             // Check private field or model fields
-            if (name.startsWith("_") || pydanticVersion.isV2 && name.startsWith(MODEL_FIELD_PREFIX)) return
+            if (name.startsWith("_") || pydanticVersion.isV2 && name in PYDANTIC_V2_MODEL_RESERVED_ATTRIBUTES) return
 
             if (pyClassType.isDefinition) {
                 if(field == null && node.reference?.resolve() is PyTargetExpression) return

--- a/testData/inspectionv2/extra.py
+++ b/testData/inspectionv2/extra.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class A(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    model_233: str
+    model_id: int
+    name: str
+
+
+# model_233, model_id are valid fields - no errors
+a = A(model_233="bert", model_id=1, name="test")
+
+# b is an undefined field - error
+A(model_233="bert", model_id=1, name="test", <error descr="'b' extra fields not permitted">b='123'</error>)

--- a/testSrc/com/koxudaxi/pydantic/PydanticInspectionV2Test.kt
+++ b/testSrc/com/koxudaxi/pydantic/PydanticInspectionV2Test.kt
@@ -48,4 +48,8 @@ open class PydanticInspectionV2Test : PydanticInspectionBase(version = "v2") {
     fun testPrivateFieldsBaseModelAlias() {
         doTest()
     }
+
+    fun testExtra() {
+        doTest()
+    }
 }


### PR DESCRIPTION
## Summary

- Fix false positive "extra fields not permitted" error for user-defined fields starting with `model_` prefix (e.g., `model_233`, `model_id`, `model_name`)
- Change field validation from prefix-based exclusion to exact match against actual BaseModel reserved attributes

Fixes #1103 #1094