### PR TITLE
Fix false positive "Frozen dataclasses" error for Pydantic models

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -35,5 +35,8 @@
         <lang.inspectionSuppressor language="Python"
                                    implementationClass="com.koxudaxi.pydantic.PydanticTypeIgnoreInspectionSuppressor"/>
 
+        <lang.inspectionSuppressor language="Python"
+                                   implementationClass="com.koxudaxi.pydantic.PydanticDataclassInspectionSuppressor"/>
+
     </extensions>
 </idea-plugin>

--- a/src/com/koxudaxi/pydantic/PydanticDataclassInspectionSuppressor.kt
+++ b/src/com/koxudaxi/pydantic/PydanticDataclassInspectionSuppressor.kt
@@ -1,0 +1,28 @@
+package com.koxudaxi.pydantic
+
+import com.intellij.codeInspection.InspectionSuppressor
+import com.intellij.codeInspection.SuppressQuickFix
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
+import com.jetbrains.python.psi.PyClass
+import com.jetbrains.python.psi.PyFile
+import com.jetbrains.python.psi.types.TypeEvalContext
+
+class PydanticDataclassInspectionSuppressor : InspectionSuppressor {
+
+    override fun isSuppressedFor(element: PsiElement, toolId: String): Boolean {
+        if (element is PsiFile) return false
+        if (element.containingFile !is PyFile) return false
+        if (toolId != "PyDataclass") return false
+
+        val pyClass = PsiTreeUtil.getParentOfType(element, PyClass::class.java, false) ?: return false
+
+        val context = TypeEvalContext.codeAnalysis(pyClass.project, pyClass.containingFile)
+        return isPydanticModel(pyClass, false, context)
+    }
+
+    override fun getSuppressActions(element: PsiElement?, toolId: String): Array<SuppressQuickFix> {
+        return SuppressQuickFix.EMPTY_ARRAY
+    }
+}

--- a/src/com/koxudaxi/pydantic/PydanticPythonPackageManagementListener.kt
+++ b/src/com/koxudaxi/pydantic/PydanticPythonPackageManagementListener.kt
@@ -2,24 +2,38 @@ package com.koxudaxi.pydantic
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.platform.ide.progress.withBackgroundProgress
 import com.jetbrains.python.packaging.common.PythonPackageManagementListener
 import com.jetbrains.python.sdk.PythonSdkUtil
 import com.jetbrains.python.sdk.PythonSdkUtil.isDisposed
 import com.jetbrains.python.statistics.sdks
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 class PydanticPythonPackageManagementListener : PythonPackageManagementListener {
+    private val scope = CoroutineScope(Dispatchers.Default)
+
     private fun updateVersion(sdk: Sdk) {
-        ProjectManager.getInstance().openProjects
-            .filter { it.sdks.contains(sdk) }
-            .forEach {
-                PydanticCacheService.clear(it)
-                val version = getPydanticVersion(it, sdk)
+        val projects = ProjectManager.getInstance().openProjects.filter { it.sdks.contains(sdk) }
+        for (project in projects) {
+            updateVersionForProject(project, sdk)
+        }
+    }
+
+    private fun updateVersionForProject(project: Project, sdk: Sdk) {
+        PydanticCacheService.clear(project)
+        scope.launch {
+            withBackgroundProgress(project, "Updating Pydantic version cache") {
+                val version = getPydanticVersion(project, sdk)
                 if (version is String) {
-                    PydanticCacheService.getOrPutVersionFromVersionCache(it, version)
+                    PydanticCacheService.getOrPutVersionFromVersionCache(project, version)
                 }
             }
+        }
     }
 
     override fun packagesChanged(sdk: Sdk) {

--- a/testData/inspectionv2/frozenClassArgument.py
+++ b/testData/inspectionv2/frozenClassArgument.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+
+
+class Foo(BaseModel, frozen=True):
+    a: str
+
+
+class Bar(BaseModel):
+    b: int
+
+
+class ChildFrozen(Bar, frozen=True):
+    c: str
+
+
+Foo(a="hello")
+Bar(b=1)
+ChildFrozen(b=2, c="world")

--- a/testSrc/com/koxudaxi/pydantic/PydanticInspectionV2Test.kt
+++ b/testSrc/com/koxudaxi/pydantic/PydanticInspectionV2Test.kt
@@ -52,4 +52,8 @@ open class PydanticInspectionV2Test : PydanticInspectionBase(version = "v2") {
     fun testExtra() {
         doTest()
     }
+
+    fun testFrozenClassArgument() {
+        doTest()
+    }
 }


### PR DESCRIPTION
## Summary
- Suppress `PyDataclass` inspection for Pydantic models to fix false positive errors
- Fix EDT blocking operation error in `PydanticPythonPackageManagementListener`

Fixes #1096
