### PR TITLE
Fix crash while typing Python functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix crash while typing Python functions [[#1180](https://github.com/koxudaxi/pydantic-pycharm-plugin/pull/1180)]
+
 ## [0.4.25] - 2026-07-01
 
 - Better support for accessing class attributes on table SQLModel models [[#1173](https://github.com/koxudaxi/pydantic-pycharm-plugin/pull/1173)]

--- a/src/com/koxudaxi/pydantic/Pydantic.kt
+++ b/src/com/koxudaxi/pydantic/Pydantic.kt
@@ -349,9 +349,10 @@ internal val PyKeywordArgument.value: PyExpression?
             else -> value
         }
 
-internal fun PyFunction.hasModelValidatorModeAfter(): Boolean = decoratorList?.decorators
+internal fun PyFunction.hasModelValidatorModeAfter(): Boolean = (this as? PyDecoratable)?.decoratorList?.decorators
+    ?.filter { it.include(MODEL_VALIDATOR_QUALIFIED_NAMES) }
     ?.any { modelValidator ->
-        modelValidator.hasModeAfter && modelValidator.include(MODEL_VALIDATOR_QUALIFIED_NAMES)
+        modelValidator.hasModeAfter
     } ?: false
 internal val PyClass.isConfigClass: Boolean get() = name == "Config"
 

--- a/src/com/koxudaxi/pydantic/Pydantic.kt
+++ b/src/com/koxudaxi/pydantic/Pydantic.kt
@@ -327,9 +327,7 @@ private val PyDecorator.resolvedQualifiedNames
     }
 
 internal fun PyDecorator.include(refNames: List<QualifiedName>): Boolean =
-    resolvedQualifiedNames.any { decoratorQualifiedName ->
-        refNames.any { refName -> decoratorQualifiedName == refName }
-    }
+    resolvedQualifiedNames.any { it in refNames }
 
 private val PyDecorator.hasModeAfter: Boolean
     get() = argumentList?.getKeywordArgument("mode")

--- a/src/com/koxudaxi/pydantic/Pydantic.kt
+++ b/src/com/koxudaxi/pydantic/Pydantic.kt
@@ -320,11 +320,30 @@ internal fun isDataclassMissing(pyTargetExpression: PyTargetExpression): Boolean
 internal fun PyFunction.hasValidatorMethod(pydanticVersion: KotlinVersion?): Boolean =
     hasDecorator(this, if(pydanticVersion.isV2) V2_VALIDATOR_QUALIFIED_NAMES else VALIDATOR_QUALIFIED_NAMES)
 
-internal fun PyDecorator.include(refNames: List<QualifiedName>): Boolean = (callee as? PyReferenceExpression)?.let {
-        PyResolveUtil.resolveImportedElementQNameLocally(it).any { decoratorQualifiedName ->
-            refNames.any { refName -> decoratorQualifiedName == refName }
+private val PyDecorator.resolvedQualifiedNames
+    get(): List<QualifiedName> {
+        val reference = callee as? PyReferenceExpression ?: return emptyList()
+        return PyResolveUtil.resolveImportedElementQNameLocally(reference)
+    }
+
+internal fun PyDecorator.include(refNames: List<QualifiedName>): Boolean =
+    resolvedQualifiedNames.any { decoratorQualifiedName ->
+        refNames.any { refName -> decoratorQualifiedName == refName }
+    }
+
+private val PyDecorator.hasModeAfter: Boolean
+    get() = argumentList?.getKeywordArgument("mode")
+        ?.let { it.value as? PyStringLiteralExpression }?.stringValue == "after"
+
+internal fun PyFunction.hasValidatorMethodForTypedHandler(): Boolean {
+    val decorators = decoratorList ?: return false
+    return decorators.decorators.any { decorator ->
+        decorator.resolvedQualifiedNames.any { qualifiedName ->
+            qualifiedName in V2_VALIDATOR_QUALIFIED_NAMES &&
+                (qualifiedName !in MODEL_VALIDATOR_QUALIFIED_NAMES || !decorator.hasModeAfter)
         }
-} ?: false
+    }
+}
 
 internal val PyKeywordArgument.value: PyExpression?
     get() = when (val value = valueExpression) {
@@ -332,11 +351,9 @@ internal val PyKeywordArgument.value: PyExpression?
             else -> value
         }
 
-internal fun PyFunction.hasModelValidatorModeAfter(): Boolean = (this as? PyDecoratable)?.decoratorList?.decorators
-    ?.filter { it.include(MODEL_VALIDATOR_QUALIFIED_NAMES) }
+internal fun PyFunction.hasModelValidatorModeAfter(): Boolean = decoratorList?.decorators
     ?.any { modelValidator ->
-        modelValidator.argumentList?.getKeywordArgument("mode")
-            ?.let { it.value as? PyStringLiteralExpression }?.stringValue == "after"
+        modelValidator.hasModeAfter && modelValidator.include(MODEL_VALIDATOR_QUALIFIED_NAMES)
     } ?: false
 internal val PyClass.isConfigClass: Boolean get() = name == "Config"
 

--- a/src/com/koxudaxi/pydantic/PydanticTypedValidatorMethodHandler.kt
+++ b/src/com/koxudaxi/pydantic/PydanticTypedValidatorMethodHandler.kt
@@ -52,7 +52,7 @@ class PydanticTypedValidatorMethodHandler : TypedHandlerDelegate() {
                 val defNode = maybeDef.node
                 if (defNode != null && defNode.elementType === PyTokenTypes.DEF_KEYWORD) {
                     val pyFunction = token.parent as? PyFunction ?: return Result.CONTINUE
-                    if (!pyFunction.hasValidatorMethod(PydanticCacheService.getVersion(project))) return Result.CONTINUE
+                    if (!pyFunction.hasValidatorMethodForTypedHandler()) return Result.CONTINUE
                     val settings = CodeStyle.getLanguageSettings(file, PythonLanguage.getInstance())
                     val textToType = StringBuilder()
                     textToType.append("(")

--- a/testData/typedvalidatormethodhandler/doesNotLoadPydanticVersionDuringWriteAction.py
+++ b/testData/typedvalidatormethodhandler/doesNotLoadPydanticVersionDuringWriteAction.py
@@ -1,0 +1,1 @@
+def plain_function<caret>

--- a/testData/typedvalidatormethodhandler/doesNotLoadPydanticVersionDuringWriteAction_after.py
+++ b/testData/typedvalidatormethodhandler/doesNotLoadPydanticVersionDuringWriteAction_after.py
@@ -1,0 +1,1 @@
+def plain_function(<caret>)

--- a/testData/typedvalidatormethodhandler/ignoresEmptyDecorator.py
+++ b/testData/typedvalidatormethodhandler/ignoresEmptyDecorator.py
@@ -1,0 +1,2 @@
+@
+def decorated<caret>

--- a/testData/typedvalidatormethodhandler/ignoresEmptyDecorator_after.py
+++ b/testData/typedvalidatormethodhandler/ignoresEmptyDecorator_after.py
@@ -1,0 +1,2 @@
+@
+def decorated(<caret>)

--- a/testData/typedvalidatormethodhandler/ignoresNonReferenceDecorator.py
+++ b/testData/typedvalidatormethodhandler/ignoresNonReferenceDecorator.py
@@ -1,0 +1,5 @@
+decorators = [lambda function: function]
+
+
+@decorators[0]
+def decorated<caret>

--- a/testData/typedvalidatormethodhandler/ignoresNonReferenceDecorator_after.py
+++ b/testData/typedvalidatormethodhandler/ignoresNonReferenceDecorator_after.py
@@ -1,0 +1,5 @@
+decorators = [lambda function: function]
+
+
+@decorators[0]
+def decorated(<caret>)

--- a/testData/typedvalidatormethodhandler/ignoresResolvedNonValidatorDecorator.py
+++ b/testData/typedvalidatormethodhandler/ignoresResolvedNonValidatorDecorator.py
@@ -1,0 +1,5 @@
+from dataclasses import dataclass
+
+
+@dataclass
+def decorated<caret>

--- a/testData/typedvalidatormethodhandler/ignoresResolvedNonValidatorDecorator_after.py
+++ b/testData/typedvalidatormethodhandler/ignoresResolvedNonValidatorDecorator_after.py
@@ -1,0 +1,5 @@
+from dataclasses import dataclass
+
+
+@dataclass
+def decorated(<caret>)

--- a/testData/typedvalidatormethodhandler/ignoresUnrelatedDecorator.py
+++ b/testData/typedvalidatormethodhandler/ignoresUnrelatedDecorator.py
@@ -1,0 +1,6 @@
+def unrelated_decorator(function):
+    return function
+
+
+@unrelated_decorator
+def decorated<caret>

--- a/testData/typedvalidatormethodhandler/ignoresUnrelatedDecorator_after.py
+++ b/testData/typedvalidatormethodhandler/ignoresUnrelatedDecorator_after.py
@@ -1,0 +1,6 @@
+def unrelated_decorator(function):
+    return function
+
+
+@unrelated_decorator
+def decorated(<caret>)

--- a/testData/typedvalidatormethodhandler/insertsClsForV1Validator.py
+++ b/testData/typedvalidatormethodhandler/insertsClsForV1Validator.py
@@ -1,0 +1,6 @@
+from pydantic import validator
+
+
+class Model:
+    @validator("name")
+    def validate_name<caret>

--- a/testData/typedvalidatormethodhandler/insertsClsForV1Validator_after.py
+++ b/testData/typedvalidatormethodhandler/insertsClsForV1Validator_after.py
@@ -1,0 +1,6 @@
+from pydantic import validator
+
+
+class Model:
+    @validator("name")
+    def validate_name(cls, <caret>):

--- a/testData/typedvalidatormethodhandlerv2/insertsClsForInvalidModelValidatorMode.py
+++ b/testData/typedvalidatormethodhandlerv2/insertsClsForInvalidModelValidatorMode.py
@@ -1,0 +1,6 @@
+from pydantic import model_validator
+
+
+class Model:
+    @model_validator(mode=None)
+    def validate_model<caret>

--- a/testData/typedvalidatormethodhandlerv2/insertsClsForInvalidModelValidatorMode_after.py
+++ b/testData/typedvalidatormethodhandlerv2/insertsClsForInvalidModelValidatorMode_after.py
@@ -1,0 +1,6 @@
+from pydantic import model_validator
+
+
+class Model:
+    @model_validator(mode=None)
+    def validate_model(cls, <caret>):

--- a/testData/typedvalidatormethodhandlerv2/insertsClsForModelValidatorBefore.py
+++ b/testData/typedvalidatormethodhandlerv2/insertsClsForModelValidatorBefore.py
@@ -1,0 +1,6 @@
+from pydantic import model_validator
+
+
+class Model:
+    @model_validator(mode="before")
+    def validate_model<caret>

--- a/testData/typedvalidatormethodhandlerv2/insertsClsForModelValidatorBefore_after.py
+++ b/testData/typedvalidatormethodhandlerv2/insertsClsForModelValidatorBefore_after.py
@@ -1,0 +1,6 @@
+from pydantic import model_validator
+
+
+class Model:
+    @model_validator(mode="before")
+    def validate_model(cls, <caret>):

--- a/testData/typedvalidatormethodhandlerv2/insertsClsForModelValidatorWithoutCall.py
+++ b/testData/typedvalidatormethodhandlerv2/insertsClsForModelValidatorWithoutCall.py
@@ -1,0 +1,6 @@
+from pydantic import model_validator
+
+
+class Model:
+    @model_validator
+    def validate_model<caret>

--- a/testData/typedvalidatormethodhandlerv2/insertsClsForModelValidatorWithoutCall_after.py
+++ b/testData/typedvalidatormethodhandlerv2/insertsClsForModelValidatorWithoutCall_after.py
@@ -1,0 +1,6 @@
+from pydantic import model_validator
+
+
+class Model:
+    @model_validator
+    def validate_model(cls, <caret>):

--- a/testData/typedvalidatormethodhandlerv2/insertsClsForModelValidatorWithoutMode.py
+++ b/testData/typedvalidatormethodhandlerv2/insertsClsForModelValidatorWithoutMode.py
@@ -1,0 +1,6 @@
+from pydantic import model_validator
+
+
+class Model:
+    @model_validator()
+    def validate_model<caret>

--- a/testData/typedvalidatormethodhandlerv2/insertsClsForModelValidatorWithoutMode_after.py
+++ b/testData/typedvalidatormethodhandlerv2/insertsClsForModelValidatorWithoutMode_after.py
@@ -1,0 +1,6 @@
+from pydantic import model_validator
+
+
+class Model:
+    @model_validator()
+    def validate_model(cls, <caret>):

--- a/testData/typedvalidatormethodhandlerv2/insertsClsForModelValidatorWrap.py
+++ b/testData/typedvalidatormethodhandlerv2/insertsClsForModelValidatorWrap.py
@@ -1,0 +1,6 @@
+from pydantic import model_validator
+
+
+class Model:
+    @model_validator(mode="wrap")
+    def validate_model<caret>

--- a/testData/typedvalidatormethodhandlerv2/insertsClsForModelValidatorWrap_after.py
+++ b/testData/typedvalidatormethodhandlerv2/insertsClsForModelValidatorWrap_after.py
@@ -1,0 +1,6 @@
+from pydantic import model_validator
+
+
+class Model:
+    @model_validator(mode="wrap")
+    def validate_model(cls, <caret>):

--- a/testData/typedvalidatormethodhandlerv2/insertsClsForV2Validator.py
+++ b/testData/typedvalidatormethodhandlerv2/insertsClsForV2Validator.py
@@ -1,0 +1,6 @@
+from pydantic import field_validator
+
+
+class Model:
+    @field_validator("name")
+    def validate_name<caret>

--- a/testData/typedvalidatormethodhandlerv2/insertsClsForV2Validator_after.py
+++ b/testData/typedvalidatormethodhandlerv2/insertsClsForV2Validator_after.py
@@ -1,0 +1,6 @@
+from pydantic import field_validator
+
+
+class Model:
+    @field_validator("name")
+    def validate_name(cls, <caret>):

--- a/testData/typedvalidatormethodhandlerv2/keepsSelfForModelValidatorAfter.py
+++ b/testData/typedvalidatormethodhandlerv2/keepsSelfForModelValidatorAfter.py
@@ -1,0 +1,6 @@
+from pydantic import model_validator
+
+
+class Model:
+    @model_validator(mode="after")
+    def validate_model<caret>

--- a/testData/typedvalidatormethodhandlerv2/keepsSelfForModelValidatorAfter_after.py
+++ b/testData/typedvalidatormethodhandlerv2/keepsSelfForModelValidatorAfter_after.py
@@ -1,0 +1,6 @@
+from pydantic import model_validator
+
+
+class Model:
+    @model_validator(mode="after")
+    def validate_model(self<caret>):

--- a/testSrc/com/koxudaxi/pydantic/PydanticTypedValidatorMethodHandlerTest.kt
+++ b/testSrc/com/koxudaxi/pydantic/PydanticTypedValidatorMethodHandlerTest.kt
@@ -1,0 +1,103 @@
+package com.koxudaxi.pydantic
+
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.openapi.util.registry.Registry
+import com.intellij.testFramework.IndexingTestUtil
+import com.jetbrains.python.sdk.PythonSdkUtil
+
+class PydanticTypedValidatorMethodHandlerTest : PydanticTestCase() {
+
+    fun testInsertsClsForV1Validator() {
+        configureByFile()
+        myFixture!!.type('(')
+        myFixture!!.checkResultByFile("${testDataMethodPath}_after.py")
+    }
+
+    fun testDoesNotLoadPydanticVersionDuringWriteAction() {
+        val fixture = myFixture!!
+        configureByFile()
+        val sdk = PythonSdkUtil.findPythonSdk(fixture.module)!!
+        runWriteAction {
+            ProjectRootManager.getInstance(fixture.project).projectSdk = sdk
+        }
+        IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
+        DumbService.getInstance(fixture.project).waitForSmartMode()
+        PydanticCacheService.clear(fixture.project)
+        Registry.get("ide.run.blocking.cancellable.assert.in.tests")
+            .setValue(true, fixture.testRootDisposable)
+
+        fixture.type('(')
+        fixture.checkResultByFile("${testDataMethodPath}_after.py")
+    }
+
+    fun testIgnoresUnrelatedDecorator() {
+        configureByFile()
+        myFixture!!.type('(')
+        myFixture!!.checkResultByFile("${testDataMethodPath}_after.py")
+    }
+
+    fun testIgnoresNonReferenceDecorator() {
+        configureByFile()
+        myFixture!!.type('(')
+        myFixture!!.checkResultByFile("${testDataMethodPath}_after.py")
+    }
+
+    fun testIgnoresEmptyDecorator() {
+        configureByFile()
+        myFixture!!.type('(')
+        myFixture!!.checkResultByFile("${testDataMethodPath}_after.py")
+    }
+
+    fun testIgnoresResolvedNonValidatorDecorator() {
+        configureByFile()
+        myFixture!!.type('(')
+        myFixture!!.checkResultByFile("${testDataMethodPath}_after.py")
+    }
+}
+
+class PydanticTypedValidatorMethodHandlerV2Test : PydanticTestCase("v2") {
+
+    fun testInsertsClsForV2Validator() {
+        configureByFile()
+        myFixture!!.type('(')
+        myFixture!!.checkResultByFile("${testDataMethodPath}_after.py")
+    }
+
+    fun testInsertsClsForModelValidatorBefore() {
+        configureByFile()
+        myFixture!!.type('(')
+        myFixture!!.checkResultByFile("${testDataMethodPath}_after.py")
+    }
+
+    fun testInsertsClsForModelValidatorWrap() {
+        configureByFile()
+        myFixture!!.type('(')
+        myFixture!!.checkResultByFile("${testDataMethodPath}_after.py")
+    }
+
+    fun testInsertsClsForModelValidatorWithoutCall() {
+        configureByFile()
+        myFixture!!.type('(')
+        myFixture!!.checkResultByFile("${testDataMethodPath}_after.py")
+    }
+
+    fun testInsertsClsForModelValidatorWithoutMode() {
+        configureByFile()
+        myFixture!!.type('(')
+        myFixture!!.checkResultByFile("${testDataMethodPath}_after.py")
+    }
+
+    fun testInsertsClsForInvalidModelValidatorMode() {
+        configureByFile()
+        myFixture!!.type('(')
+        myFixture!!.checkResultByFile("${testDataMethodPath}_after.py")
+    }
+
+    fun testKeepsSelfForModelValidatorAfter() {
+        configureByFile()
+        myFixture!!.type('(')
+        myFixture!!.checkResultByFile("${testDataMethodPath}_after.py")
+    }
+}


### PR DESCRIPTION
Fixes: #1172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved automatic insertion behavior for Pydantic typed validator methods across v1 and v2.
  * More accurate recognition of Pydantic v2 `model_validator` variants with stricter `mode` handling, including correct `mode="after"` behavior.
  * Preserves `self` for `after`-mode model validators.
  * Ignores unrelated, empty, non-reference, and non-validator decorators.

* **Bug Fixes**
  * Fixes a crash while typing Python functions.
  * Avoids unnecessary Pydantic version detection during write actions.

* **Tests**
  * Expanded typing/completion coverage for v1/v2 validator insertion and decorator edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->