### PR TITLE
Fix frozen private attribute inspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix frozen private attribute inspection [[#1198](https://github.com/koxudaxi/pydantic-pycharm-plugin/pull/1198)]
+
 ## [0.4.27] - 2026-07-23
 
 - Fix internal API usage [[#1183](https://github.com/koxudaxi/pydantic-pycharm-plugin/pull/1183)]

--- a/src/com/koxudaxi/pydantic/PydanticInspection.kt
+++ b/src/com/koxudaxi/pydantic/PydanticInspection.kt
@@ -376,8 +376,9 @@ class PydanticInspection : PyInspection() {
             if (pyClassType.isDefinition) return
             val pyClass = pyClassType.pyClass
             val attributeName = (node.leftHandSideExpression as? PyTargetExpressionImpl)?.name ?: return
-            val config = getConfig(pyClass, myTypeEvalContext, true)
             val version = PydanticCacheService.getVersion(pyClass.project)
+            if (version.isV2 && attributeName.startsWith('_')) return
+            val config = getConfig(pyClass, myTypeEvalContext, true)
             if (config["allow_mutation"] == false || (version?.isAtLeast(1, 8) == true && config["frozen"] == true)) {
                 registerInspectionProblem(
                         node,

--- a/testData/inspectionv2/readOnlyPropertyFrozenConfigDict.py
+++ b/testData/inspectionv2/readOnlyPropertyFrozenConfigDict.py
@@ -59,3 +59,13 @@ class J(BaseModel):
     model_config = {'frozen': True}
 J.abc = '456'
 <error descr="Property \"abc\" defined in \"J\" is read-only">J().abc = '456'</error>
+
+
+class K(BaseModel):
+    model_config = ConfigDict(frozen=True)
+    _private: int = 1
+
+    def update_private(self, value: int):
+        self._private = value
+
+K()._private = 2


### PR DESCRIPTION
Fixes: #1149
Fixes: #964

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved frozen private attribute handling for Pydantic v2 models, avoiding incorrect read-only warnings for underscore-prefixed private attributes.
* **Tests**
  * Added coverage for private fields and assignments in frozen Pydantic v2 models to ensure the inspection behaves correctly.
* **Documentation**
  * Updated the Unreleased changelog entry to reflect the frozen private attribute inspection fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->