### PR TITLE
Fix crash with legacy docstring settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix crash with legacy docstring settings [[#1201](https://github.com/koxudaxi/pydantic-pycharm-plugin/issues/1201)]
+
 ## [0.4.28] - 2026-07-29
 
 - Fix frozen private attribute inspection [[#1198](https://github.com/koxudaxi/pydantic-pycharm-plugin/pull/1198)]

--- a/src/com/koxudaxi/pydantic/PydanticAnnotator.kt
+++ b/src/com/koxudaxi/pydantic/PydanticAnnotator.kt
@@ -29,11 +29,11 @@ class PydanticAnnotator : Annotator {
 
     private fun annotatePydanticModelCallableExpression(pyCallExpression: PyCallExpression, holder: AnnotationHolder) {
         val context = TypeEvalContext.codeAnalysis(pyCallExpression.project, pyCallExpression.containingFile)
+        if (!pyCallExpression.isDefinitionCallExpression(context)) return
         val pyClassType = pyCallExpression.getPyCallableType(context) ?: return
         val pyClass = pyClassType.getPydanticModel(true, context) ?: return
         if (!isPydanticModel(pyClass, true, context)) return
         if (getPydanticModelInit(pyClass, context) != null) return
-        if (!pyCallExpression.isDefinitionCallExpression(context)) return
 
         val unFilledArguments =
             getPydanticUnFilledArguments(pyClassType, pyCallExpression, context, pyClass.isPydanticDataclass).nullize()

--- a/testData/annotator/invalidDocStringFormat.py
+++ b/testData/annotator/invalidDocStringFormat.py
@@ -1,0 +1,13 @@
+import pydantic
+
+
+class Model(pydantic.BaseModel):
+    value: str = ""
+
+
+def create_model():
+    return Model
+
+
+factory = create_model()
+factory()

--- a/testData/annotator/missingRequiredArguments.py
+++ b/testData/annotator/missingRequiredArguments.py
@@ -1,0 +1,19 @@
+import pydantic
+
+
+class NormalModel(pydantic.BaseModel):
+    value: str
+
+
+class NoqaModel(pydantic.BaseModel):
+    value: str
+
+
+class KeywordArgumentsModel(pydantic.BaseModel):
+    value: str
+
+
+NormalModel(<warning descr="null">)</warning>
+NoqaModel()  # noqa
+values = {}
+KeywordArgumentsModel(**values)

--- a/testData/search/typedModelFactoryKeywordArgument.py
+++ b/testData/search/typedModelFactoryKeywordArgument.py
@@ -1,0 +1,14 @@
+from typing import Type
+
+from pydantic import BaseModel
+
+
+class A(BaseModel):
+    abc: str
+
+
+def get_model() -> Type[A]:
+    return A
+
+
+get_model()(ab<caret>c='value')

--- a/testSrc/com/koxudaxi/pydantic/PydanticAnnotatorTest.kt
+++ b/testSrc/com/koxudaxi/pydantic/PydanticAnnotatorTest.kt
@@ -1,0 +1,39 @@
+package com.koxudaxi.pydantic
+
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.components.CustomImlComponentService
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.testFramework.fixtures.CodeInsightTestUtil
+import com.jetbrains.python.psi.PyCallExpression
+
+class PydanticAnnotatorTest : PydanticTestCase() {
+    fun testInvalidDocStringFormat() {
+        setDocStringFormat("EPYTEXT")
+        try {
+            configureByFile()
+
+            val callExpression = assertOneElement(
+                PsiTreeUtil.findChildrenOfType(myFixture!!.file, PyCallExpression::class.java)
+                    .filter { it.text == "factory()" },
+            )
+            assertEmpty(CodeInsightTestUtil.testAnnotator(PydanticAnnotator(), callExpression))
+        } finally {
+            setDocStringFormat("REST")
+        }
+    }
+
+    @Suppress("UnstableApiUsage")
+    private fun setDocStringFormat(format: String) {
+        val module = myFixture!!.module
+        val project = myFixture!!.project
+        runWriteAction {
+            CustomImlComponentService.getInstance(project).setComponentValueBlocking(
+                module,
+                "PyDocumentationSettings",
+                LegacyDocStringFormatState(format),
+            )
+        }
+    }
+
+    private class LegacyDocStringFormatState(var format: String = "")
+}

--- a/testSrc/com/koxudaxi/pydantic/PydanticAnnotatorTest.kt
+++ b/testSrc/com/koxudaxi/pydantic/PydanticAnnotatorTest.kt
@@ -7,6 +7,11 @@ import com.intellij.testFramework.fixtures.CodeInsightTestUtil
 import com.jetbrains.python.psi.PyCallExpression
 
 class PydanticAnnotatorTest : PydanticTestCase() {
+    fun testMissingRequiredArguments() {
+        configureByFile()
+        myFixture!!.checkHighlighting(true, false, true)
+    }
+
     fun testInvalidDocStringFormat() {
         setDocStringFormat("EPYTEXT")
         try {

--- a/testSrc/com/koxudaxi/pydantic/PydanticSearchTest.kt
+++ b/testSrc/com/koxudaxi/pydantic/PydanticSearchTest.kt
@@ -31,6 +31,10 @@ open class PydanticSearchTest : PydanticTestCase() {
         assertMatch(1)
     }
 
+    fun testTypedModelFactoryKeywordArgument() {
+        assertMatch(1)
+    }
+
     fun testChildField() {
         assertMatch(3)
     }


### PR DESCRIPTION
Fixes: #1201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a crash that could occur when using legacy docstring formatting with certain Pydantic model factory calls.
  - Improved callable analysis to avoid incorrect annotations in unsupported scenarios.
  - Improved compatibility when analyzing generic collection types across supported environments.
  - Improved detection of missing required arguments while respecting suppression comments and expanded keyword arguments.

- **Documentation**
  - Added an Unreleased changelog entry describing the crash fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->