### PR TITLE
Fix PyCharm 2026.2 type compatibility

### DIFF
--- a/src/com/koxudaxi/pydantic/PydanticTypeCheckerInspection.kt
+++ b/src/com/koxudaxi/pydantic/PydanticTypeCheckerInspection.kt
@@ -81,7 +81,7 @@ class PydanticTypeCheckerInspection : PyTypeCheckerInspection() {
 
             val newType = when (typeForParameter) {
                 is PyCollectionType ->
-                    typeForParameter.elementTypes.mapNotNull {
+                    typeForParameter.getTypeArgumentsCompat().mapNotNull {
                         it?.let { getTypeFromTypeMap(getTypeMap, it, cache) }
                     }.takeIf {
                         it.isNotEmpty()

--- a/src/com/koxudaxi/pydantic/PydanticTypeProvider.kt
+++ b/src/com/koxudaxi/pydantic/PydanticTypeProvider.kt
@@ -14,6 +14,22 @@ import com.jetbrains.python.psi.resolve.PyResolveContext
 import com.jetbrains.python.psi.types.*
 import com.koxudaxi.pydantic.PydanticConfigService.Companion.getInstance
 import one.util.streamex.StreamEx
+import java.lang.invoke.MethodHandle
+import java.lang.invoke.MethodHandles
+import java.lang.invoke.MethodType
+
+private val pyCollectionTypeArgumentsGetter: MethodHandle = run {
+    val methodType = MethodType.methodType(List::class.java)
+    try {
+        MethodHandles.publicLookup().findVirtual(PyCollectionType::class.java, "getTypeArguments", methodType)
+    } catch (_: NoSuchMethodException) {
+        MethodHandles.publicLookup().findVirtual(PyCollectionType::class.java, "getElementTypes", methodType)
+    }
+}
+
+@Suppress("UNCHECKED_CAST")
+internal fun PyCollectionType.getTypeArgumentsCompat(): List<PyType?> =
+    pyCollectionTypeArgumentsGetter.invokeExact(this) as List<PyType?>
 
 class PydanticTypeProvider : PyTypeProviderBase() {
     private val pyTypingTypeProvider = PyTypingTypeProvider()
@@ -292,7 +308,7 @@ class PydanticTypeProvider : PyTypeProviderBase() {
 
     private fun collectGenericTypes(pyClass: PyClass, context: TypeEvalContext): List<PyTypeVarType> {
         @Suppress("UnstableApiUsage") val pyCollectionType = pyTypingTypeProvider.getGenericType(pyClass, context) as? PyCollectionType
-        val genericTypes = pyCollectionType?.elementTypes?.filterIsInstance<PyTypeVarType>() ?: emptyList()
+        val genericTypes = pyCollectionType?.getTypeArgumentsCompat()?.filterIsInstance<PyTypeVarType>() ?: emptyList()
         return (genericTypes +
                 pyClass.superClassExpressions
                     .mapNotNull {

--- a/testData/typecheckerinspection/instrumentedAttributeType.py
+++ b/testData/typecheckerinspection/instrumentedAttributeType.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel
+from sqlalchemy.orm.attributes import InstrumentedAttribute
+
+
+class B:
+    pass
+
+
+class A(BaseModel):
+    value: InstrumentedAttribute[str]
+
+
+value: InstrumentedAttribute[int]
+
+
+A(<warning descr="Field is of type 'InstrumentedAttribute[str]', 'InstrumentedAttribute[int]' may not be parsable to 'InstrumentedAttribute[str]'">value=value</warning>)
+A(<warning descr="Expected type 'InstrumentedAttribute[str]', got 'B' instead">value=B()</warning>)

--- a/testSrc/com/koxudaxi/pydantic/PydanticTypeCheckerInspectionTest.kt
+++ b/testSrc/com/koxudaxi/pydantic/PydanticTypeCheckerInspectionTest.kt
@@ -17,6 +17,17 @@ open class PydanticTypeCheckerInspectionTest : PydanticInspectionBase() {
         doTest()
     }
 
+    fun testInstrumentedAttributeType() {
+        val configService = PydanticConfigService.getInstance(myFixture!!.project)
+        val previousParsableTypeMap = configService.parsableTypeMap
+        try {
+            configService.parsableTypeMap = mapOf("builtins.str" to listOf("int"))
+            doTest()
+        } finally {
+            configService.parsableTypeMap = previousParsableTypeMap
+        }
+    }
+
     fun testParsableTypeCollection() = runTestRunnable {
         suspend {
             val pydanticConfigService = PydanticConfigService.getInstance(myFixture!!.project)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when analyzing generic collection types across supported Python and IDE versions.
  * Fixed type resolution for mapped Pydantic collection fields, providing more consistent inspection results.
  * Improved type checking for Pydantic models using SQLAlchemy instrumented attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->